### PR TITLE
Fix nondeterministic buildout.txt test failure

### DIFF
--- a/src/zc/buildout/buildout.txt
+++ b/src/zc/buildout/buildout.txt
@@ -435,6 +435,10 @@ the mkdir recipe to support multiple paths:
     ...         pass
     ... """)
 
+..
+
+    >>> clean_up_pyc(sample_buildout, 'recipes', 'mkdir.py')
+
 If there is an error creating a path, the install method will exit and
 leave previously created paths in place:
 
@@ -550,6 +554,10 @@ Let's fix the recipe:
     ...         pass
     ... """)
 
+..
+
+    >>> clean_up_pyc(sample_buildout, 'recipes', 'mkdir.py')
+
 And put back the typo:
 
     >>> write(sample_buildout, 'buildout.cfg',
@@ -579,11 +587,6 @@ When we rerun the buildout:
     Traceback (most recent call last):
     ...
     OSError: ... exists...
-
-.. Wait for the file to really disappear. My linux is weird.
-
-    >>> wait_until("foo goes away", lambda : not os.path.exists('foo'),
-    ...            timeout=200)
 
 we get the same error, but we don't get the directory left behind:
 
@@ -638,12 +641,7 @@ recipe:
 
 ..
 
-    >>> for path in (
-    ...     join(sample_buildout, 'recipes', 'mkdir.pyc'),
-    ...     join(sample_buildout, 'recipes', '__pycache__', 'mkdir.pyc'),
-    ...     ):
-    ...     if os.path.exists(path):
-    ...         remove(path)
+    >>> clean_up_pyc(sample_buildout, 'recipes', 'mkdir.py')
 
 We returned by calling created, taking advantage of the fact that it
 returns the registered paths.  We did this for illustrative purposes.

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -93,6 +93,17 @@ def write(dir, *args):
     fsync(f.fileno())
     f.close()
 
+def clean_up_pyc(*path):
+    base, filename = os.path.join(*path[:-1]), path[-1]
+    if filename.endswith('.py'):
+        filename += 'c' # .py -> .pyc
+    for path in (
+        os.path.join(base, filename),
+        os.path.join(base, '__pycache__', filename),
+        ):
+        if os.path.exists(path):
+            remove(path)
+
 ## FIXME - check for other platforms
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
 
@@ -264,6 +275,7 @@ def buildoutSetUp(test):
         buildout = os.path.join(sample, 'bin', 'buildout'),
         wait_until = wait_until,
         print_ = print_,
+        clean_up_pyc = clean_up_pyc,
         ))
 
     zc.buildout.easy_install.prefer_final(prefer_final)


### PR DESCRIPTION
If the test happened to write to mkdir.py twice in the same second,
Python's import cache wouldn't notice that the .pyc file is stale and
would execute old code.

Fixes http://travis-ci.org/#!/buildout/buildout/jobs/2178437
