### PR TITLE
Removed '-v' verbosity option from bin/test (just trying something)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ clean:
 	rm -rf $(BUILD_DIRS)
 
 test:
-	$(HERE)/bin/test -v -1
+	$(HERE)/bin/test -1


### PR DESCRIPTION
Removing the verbosity might make it more obvious where the two failures occur that zc.recipe.testrunner insists exist when running on travis.

I've done it as a pull request to get travis to build it. No need to do anything till Travis reports success :-)
