### PR TITLE
Drop trove classifiers for Python 2.4 and 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,6 @@ setup(
        'License :: OSI Approved :: Zope Public License',
        'Programming Language :: Python',
        'Programming Language :: Python :: 3',
-       'Programming Language :: Python :: 2.4',
-       'Programming Language :: Python :: 2.5',
        'Programming Language :: Python :: 2.6',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3.2',


### PR DESCRIPTION
README.rst claims only 2.6, 2.7, 3.2 and 3.3 are supported.
