### PR TITLE
Small README .rst syntax improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,9 @@ This version of buildout is available from the github project
 download page, not from pypi.
 
 To get the bootstrap.py file for this release of buildout, get
-``http://downloads.buildout.org/2/bootstrap.py``.
+http://downloads.buildout.org/2/bootstrap.py.
 
-For example, using wget:
+For example, using wget::
 
   wget http://downloads.buildout.org/2/bootstrap.py
 


### PR DESCRIPTION
The download link for the bootstrap is now clickable.

The wget commandline is a proper commandline instead of a blockquote.
