### PR TITLE
Add bin/buildout --version

### DIFF
--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1601,6 +1601,10 @@ Options:
 
      Print this message and exit.
 
+  --version
+
+     Print buildout version number and exit.
+
   -v
 
      Increase the level of verbosity.  This option can be used multiple times.
@@ -1706,8 +1710,15 @@ Commands:
     COMPUTED_VALUE, DEFAULT_VALUE, COMMAND_LINE_VALUE).
 
 """
+
 def _help():
     print_(_usage)
+    sys.exit(0)
+
+def _version():
+    version = pkg_resources.working_set.find(
+                pkg_resources.Requirement.parse('zc.buildout')).version
+    print_("buildout version %s" % version)
     sys.exit(0)
 
 def main(args=None):
@@ -1772,6 +1783,8 @@ def main(args=None):
             elif op:
                 if orig_op == '--help':
                     _help()
+                elif orig_op == '--version':
+                    _version()
                 _error("Invalid option", '-'+op[0])
         elif '=' in args[0]:
             option, value = args.pop(0).split('=', 1)

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -595,6 +595,15 @@ def test_help():
     ...
     """
 
+def test_version():
+    """
+    >>> buildout = os.path.join(sample_buildout, 'bin', 'buildout')
+    >>> print_(system(buildout+' --version'))
+    ... # doctest: +ELLIPSIS
+    buildout version ...
+
+    """
+
 def test_bootstrap_with_extension():
     """
 We had a problem running a bootstrap with an extension.  Let's make


### PR DESCRIPTION
Currently to see which version of zc.buildout I've got, I have to open bin/buildout in a text editor and look at the version number in the filename of the buildout egg included in sys.path. I'd like a simpler way. Having the --version command line argument print the version number and exit without doing anything else is traditional.

Fixes https://bugs.launchpad.net/zc.buildout/+bug/309770
