### PR TITLE
Corrected travis image link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Buildout
    :width: 82px
    :height: 13px
    :alt: Travis CI build report
-   :target: https://secure.travis-ci.org/#!/buildout/buildout
+   :target: https://travis-ci.org/buildout/buildout
 
 Buildout is a project designed to solve 2 problems:
 


### PR DESCRIPTION
The old "hashbang" url redirected to https://travis-ci.org//buildout/buildout, with two slashes, which didn't work. Travis bug, but using the new https://travis-ci.org/buildout/buildout url ourselves is easier :-)
