### PR TITLE
Picked packages are reported in lowercase.

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -519,13 +519,13 @@ class Installer:
                  and
                  requirement.specs[0][0] == '==')
                 ):
-                logger.debug('Picked: %s = %s',
-                             dist.project_name, dist.version)
-                self._picked_versions[dist.project_name] = dist.version
+                name = dist.project_name.lower()
+                logger.debug('Picked: %s = %s', name, dist.version)
+                self._picked_versions[name] = dist.version
 
                 if not self._allow_picked_versions:
                     raise zc.buildout.UserError(
-                        'Picked: %s = %s' % (dist.project_name, dist.version)
+                        'Picked: %s = %s' % (name, dist.version)
                         )
 
         return dists

--- a/src/zc/buildout/repeatable.txt
+++ b/src/zc/buildout/repeatable.txt
@@ -16,7 +16,8 @@ To support repeatable buildouts, a versions section can be created
 with options for each distribution name whos version is to be fixed.
 The section can then be specified via the buildout versions option.
 
-To see how this works, we'll create two versions of a recipe egg:
+To see how this works, we'll create two versions of a recipe egg. Note that we
+give the second a capitalized name to test case-insensitiveness:
 
     >>> mkdir('recipe')
     >>> write('recipe', 'recipe.py',
@@ -62,11 +63,10 @@ To see how this works, we'll create two versions of a recipe egg:
     >>> write('recipe', 'setup.py',
     ... '''
     ... from setuptools import setup
-    ... setup(name='spam', version='2', py_modules=['recipe'],
+    ... setup(name='Spam', version='2', py_modules=['recipe'],
     ...       entry_points={'zc.buildout': ['default = recipe:Recipe']},
     ...       )
     ... ''')
-
 
     >>> print_(system(buildout+' setup recipe bdist_egg')) # doctest: +ELLIPSIS
     Running setup script 'recipe/setup.py'.
@@ -88,7 +88,7 @@ If we run the buildout, it will use version 2:
 
     >>> print_(system(buildout), end='')
     Getting distribution for 'spam'.
-    Got spam 2.
+    Got Spam 2.
     Installing foo.
     recipe v2
 
@@ -259,6 +259,10 @@ versions it picked at the end of its run:
     [versions]
     distribute = 0.6.99
     spam = 2
+
+Note that the ``Spam`` version is reported as ``spam``. The python package
+index is case-insensitive. Keeping everything lowercase makes that clear and
+makes sorting easier.
 
 When everything is pinned, no output is generated:
 


### PR DESCRIPTION
Packages in the version list are already case-insensitive, but when a
package like 'Sphinx' or 'Django' is picked, the reported version pin
still looked like 'Django = 1.4.3'. To make sorting easier and to
prevent confusion, 'django = 1.4.3', all lowercase, is better.

The only place where the "real" case is reported is somewhere in the
setuptools dist matching where the dist is printed directly. I
haven't put a str(dist).lower() around that, it seemed pretty internal.

Note: I'd consider this to be a new feature, not a bugfix. As such it is not for 2.0.1/2.0.2, but for 2.1.

Suggested changelog entry: "Picked packages are reported in lowercase now."
