### PR TITLE
Use umask when doing "chmod +x". Improved version of pull request #18

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -119,7 +119,12 @@ def call_subprocess(args, **kw):
 
 
 def _execute_permission():
-    return 493  # 0755, -rwxr-xr-x
+    current_umask = os.umask(0o022)
+    # os.umask only returns the current umask if you also give it one, so we
+    # have to give it a dummy one and immediately set it back to the real
+    # value...  Distribute does the same.
+    os.umask(current_umask)
+    return 0o777 - current_umask
 
 
 _easy_install_cmd = 'from setuptools.command.easy_install import main; main()'

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -705,6 +705,16 @@ The scripts that are generated are made executable:
     ...     os.access(os.path.join(bin, 'run'), os.X_OK)
     True
 
+For setting the executable permission, the user's umask is honored:
+
+    >>> orig_umask = os.umask(0o077)  # Only user gets permissions.
+    >>> zc.buildout.easy_install._execute_permission() == 0o700
+    True
+    >>> tmp = os.umask(0o022)  # User can write, the rest not.
+    >>> zc.buildout.easy_install._execute_permission() == 0o755
+    True
+    >>> tmp = os.umask(orig_umask)  # Reset umask to the original value.
+
 
 Including extra paths in scripts
 --------------------------------


### PR DESCRIPTION
This improves upon #18:
- Tests, woohoo!
- The permissions are set correctly. #18 would always set the executable bits, giving you for instance `-rwx--x--x` where you would expect `-rwx------`.
- The method used is the one Distrubute uses. 
