### PR TITLE
Empty "eggs=" interpreter fix. Fixes #79

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1157,6 +1157,8 @@ def _pyscript(path, dest, rsetup, initialization=''):
         dest += '-script.py'
 
     python = _safe_arg(sys.executable)
+    if path:
+        path += ','  # Courtesy comma at the end of the list.
 
     contents = py_script_template % dict(
         python = python,
@@ -1191,7 +1193,7 @@ py_script_template = script_header + '''\
 import sys
 
 sys.path[0:0] = [
-  %(path)s,
+  %(path)s
   ]
 %(initialization)s
 

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -681,15 +681,14 @@ An interpreter can also be generated without other eggs:
 
     >>> scripts = zc.buildout.easy_install.scripts(
     ...     [], [], sys.executable, bin, interpreter='py')
-    >>> cat(bin, 'py') # doctest: +NORMALIZE_WHITESPACE
+    >>> cat(bin, 'py') # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
     #!/usr/local/bin/python2.7
     <BLANKLINE>
     import sys
     <BLANKLINE>
     sys.path[0:0] = [
-      ]
     <BLANKLINE>
-    _interactive = True
+      ]
     ...
 
 An additional argument can be passed to define which scripts to install


### PR DESCRIPTION
One note: I guess the sentence in the docstring could be worded better:
https://github.com/reinout/buildout/compare/empty-eggs-interpreter-fix#L1R680
