### PR TITLE
Removed buildout.dumppickedversions from the warning. Partial fix for #70

### DIFF
--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -953,13 +953,15 @@ class Buildout(DictMixin):
     def _load_extensions(self):
         __doing__ = 'Loading extensions.'
         specs = self['buildout'].get('extensions', '').split()
-        if 'buildout-versions' in specs:
-            raise zc.buildout.UserError(
-                "The extension 'buildout-versions' is now included in "
-                "buildout itself.\n"
-                "Remove the extension from your configuration and "
-                "look at the `show-picked-versions`\n"
-                "option in buildout's documentation.")
+        for superceded_extension in ['buildout-versions',
+                                     'buildout.dumppickedversions']:
+            if superceded_extension in specs:
+                msg = ("Buildout now includes 'buildout-versions' (and part "
+                       "of the older 'buildout.dumppickedversions').\n"
+                       "Remove the extension from your configuration and "
+                       "look at the 'show-picked-versions' option in "
+                       "buildout's documentation.")
+                raise zc.buildout.UserError(msg)
         if specs:
             path = [self['buildout']['develop-eggs-directory']]
             if self.offline:

--- a/src/zc/buildout/repeatable.txt
+++ b/src/zc/buildout/repeatable.txt
@@ -421,10 +421,11 @@ configured.
     ... [foo]
     ... recipe = spam
     ... """)
-    >>> print_(system(buildout), end='') # doctest: +ELLIPSIS
+    >>> print_(system(buildout), end='') # doctest: +NORMALIZE_WHITESPACE
     While:
       Installing.
       Loading extensions.
-    Error: The extension 'buildout-versions' is now included in buildout itself.
-    Remove the extension from your configuration and look at the `show-picked-versions`
-    option in buildout's documentation.
+      Error: Buildout now includes 'buildout-versions'
+      (and part of the older 'buildout.dumppickedversions').
+      Remove the extension from your configuration and look at the
+      'show-picked-versions' option in buildout's documentation.


### PR DESCRIPTION
I _have_ retained buildout.dumppickedversions in the doctest with
the qualification 'only part of it'.

Removing the warning _does_ make it less obvious for the people
that use buildout.dumppickedversions in the way I thought it
was used most, but apparently the default behaviour of dumppickedversions
was otherwise.
