### PR TITLE
Updating the master version to dev: should we increment the version while in dev?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 name = "zc.buildout"
-version = "2.0.1"
+version = "2.1.0dev"
 
 import os
 from setuptools import setup


### PR DESCRIPTION
@jimfulton ... I think we should increment the version number while in dev such that built dev versions, released or not, can be easily tested locally without conflicts with older versions.
