### PR TITLE
Use API for loading platform-relevant launcher on Windows

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -26,6 +26,7 @@ import pkg_resources
 import py_compile
 import re
 import setuptools.archive_util
+import setuptools.command.easy_install
 import setuptools.command.setopt
 import setuptools.package_index
 import shutil


### PR DESCRIPTION
In #117, buildout was broken because Distribute removed deprecated executables from the package. Buildout shouldn't depend on these files in the package, but instead should depend on an API to load those files in a platform-aware way.

In the past, no such API existed, but I'm considering adding one to Distribute for just this reason. This PR demonstrates how that API would be consumed from buildout (including a fallback for backward compatibility).

Please provide feedback. Would this technique work? Would you do it differently? Any other comments or suggestions?
