### PR TITLE
distribute / setuptools noise OFF.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change History
 2.1.1dev (unreleased)
 =====================
 
+- Suppress the useless ``Link to <URL> ***BLOCKED*** by --allow-hosts``
+  error message being emitted by distribute / setuptools.
+
 2.1.0 (2013-03-23)
 ==================
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -81,6 +81,25 @@ buildout_and_distribute_path = [
 
 FILE_SCHEME = re.compile('file://', re.I).match
 
+class _Monkey(object):
+    def __init__(self, module, **kw):
+        mdict = self._mdict = module.__dict__
+        self._before = mdict.copy()
+        self._overrides = kw
+
+    def __enter__(self):
+        self._mdict.update(self._overrides)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._mdict.clear()
+        self._mdict.update(self._before)
+ 
+class _NoWarn(object):
+    def warn(self, *args, **kw):
+        pass
+
+_no_warn = _NoWarn()
 
 class AllowHostsPackageIndex(setuptools.package_index.PackageIndex):
     """Will allow urls that are local to the system.
@@ -90,7 +109,12 @@ class AllowHostsPackageIndex(setuptools.package_index.PackageIndex):
     def url_ok(self, url, fatal=False):
         if FILE_SCHEME(url):
             return True
-        return setuptools.package_index.PackageIndex.url_ok(self, url, False)
+        # distutils has its own logging, which can't be hooked / suppressed,
+        # so we monkey-patch the 'log' submodule to suppress the stupid
+        # "Link to <URL> ***BLOCKED*** by --allow-hosts" message.
+        with _Monkey(setuptools.package_index, log=_no_warn):
+            return setuptools.package_index.PackageIndex.url_ok(
+                                                self, url, False)
 
 
 _indexes = {}


### PR DESCRIPTION
Suppressing the stupid 'Link to <URL> **_BLOCKED**_ by --allow-hosts' warning.

Because distutils doesn't use the 'logging' module (or 'warnings' framework), the only way to suppress the noise is to monkey-patch the 'log' module imported from distutils.
