### PR TITLE
Documentation fix: Mac OS -> Mac OS X and correct short string.

### DIFF
--- a/src/zc/buildout/buildout.txt
+++ b/src/zc/buildout/buildout.txt
@@ -1240,8 +1240,8 @@ cygwin
 solaris
   We're running on solaris
 
-macos
-  We're running on Mac OS
+macosx
+  We're running on Mac OS X
 
 posix
   We're running on a POSIX-compatible system


### PR DESCRIPTION
The source code maps `macosx` to `'darwin' in sys_platform`, so this is definitely Mac OS X and not the _old_ Mac OS.
