### PR TITLE
Fix test failure due to new setuptools/distribute

### DIFF
--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -817,7 +817,7 @@ On the other hand, if we have a regular egg, rather than a develop egg:
 
     >>> ls('eggs') # doctest: +ELLIPSIS
     -  foox-0.0.0-py2.4.egg
-    -  setuptools.eggpyN.N.egg
+    d  setuptools.eggpyN.N.egg
     ...
 
 We do not get a warning, but we do get setuptools included in the working set:
@@ -3421,6 +3421,7 @@ def test_suite():
                  r'We have a develop egg: \1 V'),
                 (re.compile('Picked: setuptools = \S+'),
                  'Picked: setuptools = V'),
+                (re.compile('[-d]  setuptools'), '-  setuptools'),
                 (re.compile(r'\\[\\]?'), '/'),
                 (re.compile(
                     '-q develop -mxN -d "/sample-buildout/develop-eggs'),


### PR DESCRIPTION
Nowadays setuptools always unzips eggs.  Add a renormalizer (one that
was already used for a different test file) so that either zipped or
unzipped setuptools egg is acceptable.

You can see the failure here: https://travis-ci.org/buildout/buildout/jobs/8250089
or here: http://winbot.zope.org/builders/zc_buildout_dev%20py_265_win32%20master/builds/318/steps/test/logs/stdio
