### PR TITLE
remove dead (?) code, typofix

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -497,10 +497,6 @@ class Installer:
             try:
                 dist = self._fetch(avail, tmp, self._download_cache)
 
-                if dist is None:
-                    raise zc.buildout.UserError(
-                        "Couln't download distribution %s." % avail)
-
                 if dist.precedence == pkg_resources.EGG_DIST:
                     # It's already an egg, just fetch it into the dest
 

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -452,7 +452,7 @@ def wait(port, up):
         if up:
             raise
         else:
-            raise SystemError("Couln't stop server")
+            raise SystemError("Couldn't stop server")
 
 def install(project, destination):
     if not isinstance(destination, str):


### PR DESCRIPTION
When fixing some typos I found, I tried to add a test, but I couldn't figure out how to trigger the "Couldn't download distribution" exception, which requires ```Installer._fetch``` to return ```None```.  I can't see that happening, at least with a current ```pkg_resources.Distribution```.

If someone can give me a hint as to when this error would happen, I'd be happy to write a test.  If not, here's a pull request to remove dead code for your consideration.