### PR TITLE
fix summation and substraction from options

### DIFF
--- a/src/zc/buildout/configparser.py
+++ b/src/zc/buildout/configparser.py
@@ -215,6 +215,14 @@ def parse(fp, fpname, exp_globals=dict):
                     optname, optval = mo.group('name', 'value')
                     optname = optname.rstrip()
                     optval = optval.strip()
+                    if optname.endswith('+'):
+                        optname = optname.rstrip(' +')
+                        optval = ' '.join((cursect.get(optname, ''), optval))
+                    if optname.endswith('-'):
+                        optname = optname.rstrip(' -')
+                        optval = ' '.join(
+                            [val for val in cursect.get(optname, '').split()
+                                if val not in optval.split()])
                     cursect[optname] = optval
                     blockmode = not optval
                 elif not (optname or line.strip()):


### PR DESCRIPTION
This patch allows to increment and decrement variables within sections, inherited sections and conditional sections.
For example, you have a section, that creates a json like that:
`{"key-1": "value-1", "key-2": "value-2", "key-3": "value-3"}`

``` ini
[make-json]
recipe = recipes:jsonize
json = key-1 value-1 key-2 value-2 key-3 value-3
```

and you want to add a part `{"key-4": "value-4"}` in Mac OS X:

``` ini
[make-json:macosx]
json += key-4 value-4
```

It will not increment! It will create a separate invalid variable `json +` into **.installed.cfg**
And you will not be able to **buildout** again, because **buildout** will say: "Sorry, guy, `json +` is invalid variable format in .installed.cfg"
