### PR TITLE
Fix Makefile error when downloading Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(PYTHON_VER),3.3)
 endif
 
 PYTHON_ARCHIVE ?= Python-$(PYTHON_MINOR)
-PYTHON_DOWNLOAD = http://www.python.org/ftp/python/$(PYTHON_MINOR)/$(PYTHON_ARCHIVE).tgz
+PYTHON_DOWNLOAD = http://legacy.python.org/ftp/python/$(PYTHON_MINOR)/$(PYTHON_ARCHIVE).tgz
 PYTHON_EXE = python$(PYTHON_VER)
 
 .PHONY: all build test


### PR DESCRIPTION
Because cURL is not told to follow redirects (with a --location option), it fails to download Python.

The redirects that Python.org returns is a 301 (Moved Permanently).

Here is the flow of redirects:

http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz 301
-> https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz 301
-> http://legacy.python.org/ftp//python/2.7.3/Python-2.7.3.tgz

To honor the redirects, I've changed the download URL to point to the final URL: http://legacy.python.org/ftp//python/2.7.3/Python-2.7.3.tgz. This change fixes the Makefile and unblocks Travis CI to run integration tests.
