### PR TITLE
Fix Python tarball download in Makefile by following HTTP redirects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(PYTHON_VER),3.3)
 endif
 
 PYTHON_ARCHIVE ?= Python-$(PYTHON_MINOR)
-PYTHON_DOWNLOAD = http://www.python.org/ftp/python/$(PYTHON_MINOR)/$(PYTHON_ARCHIVE).tgz
+PYTHON_DOWNLOAD = https://www.python.org/ftp/python/$(PYTHON_MINOR)/$(PYTHON_ARCHIVE).tgz
 PYTHON_EXE = python$(PYTHON_VER)
 
 .PHONY: all build test


### PR DESCRIPTION
I'm adding the --location flag to curl, so that redirects get followed. In particular there is a sequence of two 301 redirects that the Python tarball download URL encounters.

Even though the HTTP spec defines a 301 as being a permanent change, python.org is using URLs that return 301 redirects. It's probably best to be consistent with python.org practices than to assume python.org is following the HTTP 1.1 spec (RFC 2616).
