### PR TITLE
Potential fix for https://github.com/buildout/buildout/issues/217

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -87,7 +87,11 @@ if not options.allow_site_packages:
     # We can't remove these reliably
     if hasattr(site, 'getsitepackages'):
         for sitepackage_path in site.getsitepackages():
-            sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
 


### PR DESCRIPTION
On Windows, `sys.prefix` is a site-package directory, i.e. for a
standard installation `C:\Python27`. The code path for `not
allow_site_packages` removed *everything* from `sys.path` that contains
*any* of the the site-packages directories as reported by
 `site.getsitepackages`, which on Windows removes all pathes below
 `sys.prefix` from `sys.path`.