### PR TITLE
Use local ez_setup.py if one exists; add --setuptools-download-base option

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -61,7 +61,9 @@ parser.add_option("--allow-site-packages",
                   help=("Let bootstrap.py use existing site packages"))
 parser.add_option("--setuptools-version",
                   help="use a specific setuptools version")
-
+parser.add_option("--setuptools-to-dir",
+                  help=("allow for re-use of existing directory of "
+                        "setuptools versions"))
 
 options, args = parser.parse_args()
 
@@ -77,7 +79,10 @@ except ImportError:
     from urllib2 import urlopen
 
 ez = {}
-exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 
 if not options.allow_site_packages:
     # ez_setup imports site, which adds site packages
@@ -94,6 +99,8 @@ setup_args = dict(to_dir=tmpeggs, download_delay=0)
 
 if options.setuptools_version is not None:
     setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
 
 ez['use_setuptools'](**setup_args)
 import setuptools

--- a/src/zc/buildout/bootstrap.txt
+++ b/src/zc/buildout/bootstrap.txt
@@ -127,3 +127,35 @@ Let's make sure the generated `buildout` script uses it::
       '/sample/eggs/setuptools-8.0...egg',
       '/sample/eggs/zc.buildout-2.0.0...egg',
       ]...
+
+For a completely offline install we want to avoid downloading ez_setup.py,
+specify the setuptools version, and to reuse the setuptools zipfile.
+
+    >>> try:
+    ...     from urllib.request import urlopen
+    ... except ImportError:
+    ...     from urllib2 import urlopen
+    >>> ez_setup = urlopen('https://bootstrap.pypa.io/ez_setup.py').read()
+    >>> write('ez_setup.py',
+    ... '''print("Using local ez_setup.py")
+    ... ''' + ez_setup.decode('ascii'))
+
+    >>> os.path.exists('setuptools-14.3.zip')
+    False
+
+    >>> print_('X'); print_(system(
+    ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
+    ...     'bootstrap.py --setuptools-version 14.3 --version 2.0.0 '+
+    ...     '--setuptools-to-dir .')); print_('X')
+    ... # doctest: +ELLIPSIS
+    X...Using local ez_setup.py...Generated script '/sample/bin/buildout'...X
+
+    >>> os.path.exists('setuptools-14.3.zip')
+    True
+
+    >>> print_(open(buildout_script).read()) # doctest: +ELLIPSIS
+    #...
+    sys.path[0:0] = [
+      '/sample/eggs/setuptools-14.3...egg',
+      '/sample/eggs/zc.buildout-2.0.0...egg',
+      ]...


### PR DESCRIPTION
For a completely offline install would need to make download_setuptools recognize filesystem paths for download_base.