### PR TITLE
Don't assume pkg_resources is a module.

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -50,14 +50,15 @@ except ImportError:
 exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
 ez['use_setuptools'](to_dir='eggs', download_delay=0)
 
-import pkg_resources
+import pkg_resources, setuptools
+setuptools_path = os.path.dirname(os.path.dirname(setuptools.__file__))
 
 ######################################################################
 # Install buildout
 if subprocess.call(
     [sys.executable] +
     ['setup.py', '-q', 'develop', '-m', '-x', '-d', 'develop-eggs'],
-    env=dict(os.environ, PYTHONPATH=os.path.dirname(pkg_resources.__file__))):
+    env=dict(os.environ, PYTHONPATH=setuptools_path)):
     raise RuntimeError("buildout build failed.")
 
 pkg_resources.working_set.add_entry('src')


### PR DESCRIPTION
In setuptools < 8.3 pkg_resources.py was a module, so

    import pkg_resources
    print(pkg_resources.__file__)

would print something like

    /home/mg/src/buildout/eggs/setuptools-8.0.4-py2.7.egg/pkg_resources.py

Starting from setuptools 8.3 pkg_resources became a package, so the
above code prints

    /home/mg/src/buildout/eggs/setuptools-11.3.1-py2.7.egg/pkg_resources/__init__.py

which means a single os.path.dirname() is no longer sufficient to find
the location of the .egg file/directory.

I'm pretty sure 'setuptools' itself was always a package, so use two
os.path.dirname()s on setuptools.__file__ to find the .egg location more
reliably with both old and new setuptools versions.

Fixes https://github.com/buildout/buildout/issues/227