### PR TITLE
Avoid prefixing buildout dir to 'special' rpath elements.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Change History
 **************
 
+- Fixed: In ``zc.recipe.egg#custom`` recipe's ``rpath`` support, don't
+  assume path elements are buildout-relative if they start with one of the
+  "special" tokens (e.g., ``$ORIGIN``).  See:
+  https://github.com/buildout/buildout/issues/225.
+
 - Fixed: Buildout merged single-version requirements with
   version-range requirements in a way that caused it to think there
   wasn't a single-version requirement.  IOW, buildout throught that

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,9 +22,10 @@ Unreleased
   https://github.com/buildout/buildout/pull/222 .
   [lrowe]
 
-- Fixed: In ``zc.recipe.egg#custom`` recipe's ``rpath`` support, don't
-  assume path elements are buildout-relative if they start with one of the
-  "special" tokens (e.g., ``$ORIGIN``).  See:
+- Note: zc.recipe.egg has also been updated to 2.0.2 together with this
+  zc.buildout release. Fixed: In ``zc.recipe.egg#custom`` recipe's ``rpath``
+  support, don't assume path elements are buildout-relative if they start with
+  one of the "special" tokens (e.g., ``$ORIGIN``).  See:
   https://github.com/buildout/buildout/issues/225.
   [tseaver]
 

--- a/zc.recipe.egg_/CHANGES.txt
+++ b/zc.recipe.egg_/CHANGES.txt
@@ -1,6 +1,15 @@
 Change History
 **************
 
+2.0.2 (unreleased)
+==================
+
+- Fixed: In ``zc.recipe.egg#custom`` recipe's ``rpath`` support, don't
+  assume path elements are buildout-relative if they start with one of the
+  "special" tokens (e.g., ``$ORIGIN``).  See:
+  https://github.com/buildout/buildout/issues/225.
+  [tseaver]
+
 2.0.1 (2013-09-05)
 ==================
 
@@ -129,7 +138,7 @@ Feature Changes
 
   - Cause develop eggs to be created after other parts.
 
-- The develop and build recipes now return the paths created, so that 
+- The develop and build recipes now return the paths created, so that
   created eggs or egg links are removed when a part is removed (or
   changed).
 

--- a/zc.recipe.egg_/setup.py
+++ b/zc.recipe.egg_/setup.py
@@ -14,7 +14,7 @@
 """Setup for zc.recipe.egg package
 """
 
-version = '2.0.1'
+version = '2.0.2.dev0'
 
 import os
 from setuptools import setup, find_packages

--- a/zc.recipe.egg_/src/zc/recipe/egg/custom.py
+++ b/zc.recipe.egg_/src/zc/recipe/egg/custom.py
@@ -161,8 +161,8 @@ def build_ext(buildout, options):
     if value is not None:
         values = [_prefix_non_special(v)
                     for v in value.strip().split('\n') if v.strip()]
-        result['rpath'] = os.pathsep.join(value)
-        options['rpath'] = os.pathsep.join(value)
+        result['rpath'] = os.pathsep.join(values)
+        options['rpath'] = os.pathsep.join(values)
 
     swig = options.get('swig')
     if swig:


### PR DESCRIPTION
Fixes #225.