### PR TITLE
Use 'rcN' for release candidate versions in tests

### DIFF
--- a/src/zc/buildout/downloadcache.txt
+++ b/src/zc/buildout/downloadcache.txt
@@ -37,10 +37,10 @@ download:
     <a href="demo-0.1-py2.4.egg">demo-0.1-py2.4.egg</a><br>
     <a href="demo-0.2-py2.4.egg">demo-0.2-py2.4.egg</a><br>
     <a href="demo-0.3-py2.4.egg">demo-0.3-py2.4.egg</a><br>
-    <a href="demo-0.4c1-py2.4.egg">demo-0.4c1-py2.4.egg</a><br>
+    <a href="demo-0.4rc1-py2.4.egg">demo-0.4rc1-py2.4.egg</a><br>
     <a href="demoneeded-1.0.zip">demoneeded-1.0.zip</a><br>
     <a href="demoneeded-1.1.zip">demoneeded-1.1.zip</a><br>
-    <a href="demoneeded-1.2c1.zip">demoneeded-1.2c1.zip</a><br>
+    <a href="demoneeded-1.2rc1.zip">demoneeded-1.2rc1.zip</a><br>
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="index/">index/</a><br>

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -97,10 +97,10 @@ We have a link server that has a number of eggs:
     <a href="demo-0.1-py2.4.egg">demo-0.1-py2.4.egg</a><br>
     <a href="demo-0.2-py2.4.egg">demo-0.2-py2.4.egg</a><br>
     <a href="demo-0.3-py2.4.egg">demo-0.3-py2.4.egg</a><br>
-    <a href="demo-0.4c1-py2.4.egg">demo-0.4c1-py2.4.egg</a><br>
+    <a href="demo-0.4rc1-py2.4.egg">demo-0.4rc1-py2.4.egg</a><br>
     <a href="demoneeded-1.0.zip">demoneeded-1.0.zip</a><br>
     <a href="demoneeded-1.1.zip">demoneeded-1.1.zip</a><br>
-    <a href="demoneeded-1.2c1.zip">demoneeded-1.2c1.zip</a><br>
+    <a href="demoneeded-1.2rc1.zip">demoneeded-1.2rc1.zip</a><br>
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="index/">index/</a><br>
@@ -168,15 +168,15 @@ The old setting is returned.
     ...     ['demo'], dest, links=[link_server], index=link_server+'index/')
     >>> for dist in ws:
     ...     print_(dist)
-    demo 0.4c1
-    demoneeded 1.2c1
+    demo 0.4rc1
+    demoneeded 1.2rc1
 
     >>> ls(dest)
     d  demo-0.2-py2.4.egg
     d  demo-0.3-py2.4.egg
-    d  demo-0.4c1-py2.4.egg
+    d  demo-0.4rc1-py2.4.egg
     d  demoneeded-1.1-py2.4.egg
-    d  demoneeded-1.2c1-py2.4.egg
+    d  demoneeded-1.2rc1-py2.4.egg
 
 Let's put the setting back to the default.
 
@@ -200,10 +200,10 @@ dependencies.  We might do this to specify a specific version.
     >>> ls(dest)
     d  demo-0.2-py2.4.egg
     d  demo-0.3-py2.4.egg
-    d  demo-0.4c1-py2.4.egg
+    d  demo-0.4rc1-py2.4.egg
     d  demoneeded-1.0-py2.4.egg
     d  demoneeded-1.1-py2.4.egg
-    d  demoneeded-1.2c1-py2.4.egg
+    d  demoneeded-1.2rc1-py2.4.egg
     d  other-1.0-py2.4.egg
 
     >>> rmdir(dest)
@@ -1117,10 +1117,10 @@ Let's update our link server with a new version of extdemo:
     <a href="demo-0.1-py2.4.egg">demo-0.1-py2.4.egg</a><br>
     <a href="demo-0.2-py2.4.egg">demo-0.2-py2.4.egg</a><br>
     <a href="demo-0.3-py2.4.egg">demo-0.3-py2.4.egg</a><br>
-    <a href="demo-0.4c1-py2.4.egg">demo-0.4c1-py2.4.egg</a><br>
+    <a href="demo-0.4rc1-py2.4.egg">demo-0.4rc1-py2.4.egg</a><br>
     <a href="demoneeded-1.0.zip">demoneeded-1.0.zip</a><br>
     <a href="demoneeded-1.1.zip">demoneeded-1.1.zip</a><br>
-    <a href="demoneeded-1.2c1.zip">demoneeded-1.2c1.zip</a><br>
+    <a href="demoneeded-1.2rc1.zip">demoneeded-1.2rc1.zip</a><br>
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="extdemo-1.5.zip">extdemo-1.5.zip</a><br>

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -2320,9 +2320,9 @@ distributions:
     >>> print_(system(buildout+' -v'), end='') # doctest: +ELLIPSIS
     Installing 'zc.buildout', 'setuptools'.
     ...
-    Picked: demo = 0.4c1
+    Picked: demo = 0.4rc1
     ...
-    Picked: demoneeded = 1.2c1
+    Picked: demoneeded = 1.2rc1
 
 We get an error if we specify anything but true or false:
 
@@ -2981,14 +2981,14 @@ def create_sample_eggs(test, executable=sys.executable):
 
         for i in (0, 1, 2):
             write(tmp, 'eggrecipedemoneeded.py', 'y=%s\ndef f():\n  pass' % i)
-            c1 = i==2 and 'c1' or ''
+            rc1 = i==2 and 'rc1' or ''
             write(
                 tmp, 'setup.py',
                 "from setuptools import setup\n"
                 "setup(name='demoneeded', py_modules=['eggrecipedemoneeded'],"
                 " zip_safe=True, version='1.%s%s', author='bob', url='bob', "
                 "author_email='bob')\n"
-                % (i, c1)
+                % (i, rc1)
                 )
             zc.buildout.testing.sdist(tmp, dest)
 
@@ -3032,7 +3032,7 @@ def create_sample_eggs(test, executable=sys.executable):
                 'def main():\n'
                 '   print_(x, eggrecipedemoneeded.y)\n'
                 % i)
-            c1 = i==4 and 'c1' or ''
+            rc1 = i==4 and 'rc1' or ''
             write(
                 tmp, 'setup.py',
                 "from setuptools import setup\n"
@@ -3040,7 +3040,7 @@ def create_sample_eggs(test, executable=sys.executable):
                 " install_requires = 'demoneeded',"
                 " entry_points={'console_scripts': "
                      "['demo = eggrecipedemo:main']},"
-                " zip_safe=True, version='0.%s%s')\n" % (i, c1)
+                " zip_safe=True, version='0.%s%s')\n" % (i, rc1)
                 )
             zc.buildout.testing.bdist_egg(tmp, dest)
 

--- a/zc.recipe.egg_/src/zc/recipe/egg/README.txt
+++ b/zc.recipe.egg_/src/zc/recipe/egg/README.txt
@@ -31,10 +31,10 @@ We have a link server that has a number of distributions:
     <a href="demo-0.1-py2.3.egg">demo-0.1-py2.3.egg</a><br>
     <a href="demo-0.2-py2.3.egg">demo-0.2-py2.3.egg</a><br>
     <a href="demo-0.3-py2.3.egg">demo-0.3-py2.3.egg</a><br>
-    <a href="demo-0.4c1-py2.3.egg">demo-0.4c1-py2.3.egg</a><br>
+    <a href="demo-0.4rc1-py2.3.egg">demo-0.4rc1-py2.3.egg</a><br>
     <a href="demoneeded-1.0.zip">demoneeded-1.0.zip</a><br>
     <a href="demoneeded-1.1.zip">demoneeded-1.1.zip</a><br>
-    <a href="demoneeded-1.2c1.zip">demoneeded-1.2c1.zip</a><br>
+    <a href="demoneeded-1.2rc1.zip">demoneeded-1.2rc1.zip</a><br>
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="index/">index/</a><br>


### PR DESCRIPTION
Recent setuptools versions changed the canonical spelling of release
candidate versions from 'cN' to 'rcN'.  Using the older spelling causes
a UserWarning about the version requiring normalization, and test
failures where the expected output contains a different (normalized)
version number.

For the record, the UserWarning looks like this:

/home/mg/src/buildout/eggs/setuptools-11.3.1-py2.7.egg/setuptools/dist.py:283:
UserWarning: The version specified requires normalization, consider
using '1.2rc1' instead of '1.2c1'.

and the failures can be seen at
https://travis-ci.org/buildout/buildout/jobs/46215472