### PR TITLE
Run easy_install with specified setuptools_version

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -318,7 +318,9 @@ class Installer:
         try:
             path = setuptools_loc
 
-            args = [sys.executable, '-c', _easy_install_cmd, '-mZUNxd', tmp]
+            args = [sys.executable, '-c',
+                    ('import sys; sys.path[0:0] = [%r]; ' % path) +
+                    _easy_install_cmd, '-mZUNxd', tmp]
             level = logger.getEffectiveLevel()
             if level > 0:
                 args.append('-q')
@@ -333,9 +335,7 @@ class Installer:
 
             sys.stdout.flush() # We want any pending output first
 
-            exit_code = subprocess.call(
-                list(args),
-                env=dict(os.environ, PYTHONPATH=path))
+            exit_code = subprocess.call(list(args))
 
             dists = []
             env = pkg_resources.Environment([tmp])


### PR DESCRIPTION
If setuptools is installed globally by easy_install then the easy_install.pth gets added to sys.path before PYTHONPATH and the wrong setuptools version is used.

Any chance of a 2.2.6 with this fix included?