### PR TITLE
improve index_url passing for setup_requires

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -323,6 +323,10 @@ class Installer:
             path = setuptools_loc
 
             args = [sys.executable, '-c', _easy_install_cmd, '-mZUNxd', tmp]
+            if self._index_url:
+                # pass the index_url to the easy_install_cmd to improve
+                # setup_requires behavior a bit.
+                args.extend( ('-i', self._index_url) )
             level = logger.getEffectiveLevel()
             if level > 0:
                 args.append('-q')


### PR DESCRIPTION
4 tests fail in master before and after this patch.

This patch makes setuptools respect the index_url for setup_requires entries. They still won't respect the versions list. But this is a little better.

It fixes an issue with cliff and stevedore, which use the pbr library to share setup logic.
