### PR TITLE
Travis speed improvement through caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ cache:
   - python3.2
   - python3.3
   - python3.4
+# Note on these cache directories: "make build" downloads and installs a fresh
+# python in those directories.
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ notifications:
     - buildout-development@googlegroups.com
 
 install:
+    - ls -al python*
+    - ls -al python*/bin/
     - deactivate
     - make build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ env:
 sudo: false
 cache:
   directories:
-  - python$PYTHON_VER
+  - python2.6
+  - python2.7
+  - python3.2
+  - python3.3
+  - python3.4
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,7 @@ env:
 sudo: false
 cache:
   directories:
-  - python2.6
-  - python2.7
-  - python3.2
-  - python3.3
-  - python3.4
+  - pythons
 # Note on these cache directories: "make build" downloads and installs a fresh
 # python in those directories.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ env:
     - PYTHON_VER=3.3
     - PYTHON_VER=3.4
 
+sudo: false
+cache:
+  directories:
+  - python$PYTHON_VER
+
 notifications:
   email:
     - buildout-development@googlegroups.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ notifications:
     - buildout-development@googlegroups.com
 
 install:
-    - ls -al python*
-    - ls -al python*/bin/
+    - ls -al pythons
     - deactivate
     - make build
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ sudo: false
 cache:
   directories:
   - pythons
-# Note on these cache directories: "make build" downloads and installs a fresh
-# python in those directories.
+# Note on this cache directories: "make build" downloads pythons elsewhere,
+# but installs the compiled bin/lib/share in pythons/pythonx.y/ .
 
 notifications:
   email:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Unreleased
   https://github.com/buildout/buildout/pull/222
   [lrowe]
 
+- Updated buildout's `travis-ci <https://travis-ci.org/buildout/buildout>`_
+  configuration so that tests run much quicker so that buildout is easier and
+  quicker to develop.
+  [reinout]
 
 2.3.1 (2014-12-16)
 ==================

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ BUILD_DIRS = $(PYTHON_PATH) bin build develop-eggs eggs parts
 
 all: build
 
-$(PYTHON_PATH):
+$(PYTHON_PATH)/bin/$(PYTHON_EXE):
 	@echo "Installing Python"
 	mkdir -p $(PYTHON_PATH)
 	cd $(PYTHON_PATH) && \
@@ -49,7 +49,7 @@ endif
 	make install >/dev/null 2>&1
 	@echo "Finished installing Python"
 
-build: $(PYTHON_PATH)
+build: $(PYTHON_PATH)/bin/$(PYTHON_EXE)
 	$(PYTHON_PATH)/bin/$(PYTHON_EXE) dev.py
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 HERE = $(shell pwd)
 PYTHON_VER ?= 2.7
-PYTHON_PATH = $(HERE)/python$(PYTHON_VER)
+PYTHON_PATH = $(HERE)/pythons/$(PYTHON_VER)
+PYTHON_BUILD_DIR = $(HERE)/python_builds
 
 ifeq ($(PYTHON_VER),2.6)
 	PYTHON_MINOR ?= 2.6.8
@@ -35,15 +36,16 @@ all: build
 $(PYTHON_PATH)/bin/$(PYTHON_EXE):
 	@echo "Installing Python"
 	mkdir -p $(PYTHON_PATH)
-	cd $(PYTHON_PATH) && \
+	mkdir -p $(PYTHON_BUILD_DIR)
+	cd $(PYTHON_BUILD_DIR) && \
 	curl --progress-bar --location $(PYTHON_DOWNLOAD) | tar -zx
 ifeq ($(PYTHON_VER),2.6)
-	cd $(PYTHON_PATH) && \
+	cd $(PYTHON_BUILD_DIR) && \
 	curl --progress-bar -L https://raw.github.com/collective/buildout.python/ad45adb78bfa37542d62a394392d5146fce5af34/src/issue12012-sslv2-py26.patch > ssl.patch
-	cd $(PYTHON_PATH)/$(PYTHON_ARCHIVE) && \
+	cd $(PYTHON_BUILD_DIR)/$(PYTHON_ARCHIVE) && \
 	patch -p0 < ../ssl.patch
 endif
-	cd $(PYTHON_PATH)/$(PYTHON_ARCHIVE) && \
+	cd $(PYTHON_BUILD_DIR)/$(PYTHON_ARCHIVE) && \
 	./configure --prefix $(PYTHON_PATH) $(PYTHON_CONFIGURE_ARGS) >/dev/null 2>&1 && \
 	make >/dev/null 2>&1 && \
 	make install >/dev/null 2>&1
@@ -53,7 +55,7 @@ build: $(PYTHON_PATH)/bin/$(PYTHON_EXE)
 	$(PYTHON_PATH)/bin/$(PYTHON_EXE) dev.py
 
 clean:
-	rm -rf $(BUILD_DIRS)
+	rm -rf $(BUILD_DIRS) $(PYTHON_BUILD_DIR)
 
 test:
 	$(HERE)/bin/test -1 -v


### PR DESCRIPTION
Solves #230, a little bit at least.

I adjusted the makefile: the python releases are downloaded and compiled in a directory separate from the compiled results. The compiled results are cached in travis. Keeping the cache small is essential.

The travis config now uses containers ("sudo=false"), which allows us to cache the compiled python packages. This shaves 2-3 minutes off the build.

The time is down from 8-12 minutes to 4-10 minutes. So... most of the time is still in the actual tests.

Technical note: travis doesn't (yet) distinguish caches per environment variable, like we use. So every run, when completed, tries to save its results to the cache. So one of the 5 pythons will get cached as they run at the same time... So someone (probably me) needs to re-start individual builds for individual python versions to get the cache filled for every python version. That's the best I can do now.