### PR TITLE
Bootstrap fixes, including develop-eggs removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Unreleased
   higher for this functionality.
   [lrowe]
 
+- The bootstrap script now uses ``--buildout-version`` instead of
+  ``--version`` to pick a specific buildout version.
+  [reinout]
+
 - Updated buildout's `travis-ci <https://travis-ci.org/buildout/buildout>`_
   configuration so that tests run much quicker so that buildout is easier and
   quicker to develop.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,18 @@ Unreleased
   https://github.com/buildout/buildout/pull/222 .
   [lrowe]
 
+- Updated buildout's `travis-ci <https://travis-ci.org/buildout/buildout>`_
+  configuration so that tests run much quicker so that buildout is easier and
+  quicker to develop.
+  [reinout]
+
+- A new boostrap.py file is released (version 2015-07-01).
+
+- When bootstrapping, the ``develop-eggs/`` directory is first removed. This
+  prevents old left-over ``.egg-link`` files from breaking buildout's careful
+  package collection mechanism.
+  [reinout]
+
 - Bootstrap script now accepts ``--to-dir``. Setuptools is installed there. If
   already available there, it is reused. This can be used to bootstrap
   buildout without internet access. Similarly, a local ``ez_setup.py`` is used
@@ -33,14 +45,10 @@ Unreleased
   ``--version`` to pick a specific buildout version.
   [reinout]
 
-- Updated buildout's `travis-ci <https://travis-ci.org/buildout/buildout>`_
-  configuration so that tests run much quicker so that buildout is easier and
-  quicker to develop.
-  [reinout]
-
-- When bootstrapping, the ``develop-eggs/`` directory is first removed. This
-  prevents old left-over ``.egg-link`` files from breaking buildout's careful
-  package collection mechanism.
+- The bootstrap script now accepts ``--version`` which prints the bootstrap
+  version. This version is the date the bootstrap.py was last changed. A date
+  is handier or less confusing than either tracking zc.buildout's version or
+  having a separate bootstrap version number.
   [reinout]
 
 2.3.1 (2014-12-16)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,11 @@ Unreleased
   higher for this functionality.
   [lrowe]
 
+- When bootstrapping, the ``develop-eggs/`` directory is first removed. This
+  prevents old left-over ``.egg-link`` files from breaking buildout's careful
+  package collection mechanism.
+  [reinout]
+
 2.3.1 (2014-12-16)
 ==================
 

--- a/DEVELOPERS.txt
+++ b/DEVELOPERS.txt
@@ -25,3 +25,28 @@ with them do::
 
 The actual Python compilation is only done once and then re-used. So on
 subsequent builds, only the development buildout itself needs to be redone.
+
+
+Releases: zc.buildout, zc.recipe.egg and bootstrap.py
+-----------------------------------------------------
+
+Buildout consists of two python packages that are released separately:
+zc.buildout and zc.recipe.egg. zc.recipe.egg is changed much less often than
+zc.buildout.
+
+zc.buildout's setup.py and changelog is in the same directory as this
+``DEVELOPERS.txt`` and the code is in ``src/zc/buildout``.
+
+zc.recipe.egg, including setup.py and a separate changelog, is in the
+``zc.recipe.egg_`` subdirectory.
+
+A third item is the bootstrap.py file in ``bootstrap/bootstrap.py``. The
+canonical location is at https://bootstrap.pypa.io/bootstrap-buildout.py,
+(though it is unfortunate that it isn't named just ``bootstrap.py``). This
+file is pulled automatically every 15 minutes from the bootstrap-release
+branch. When a new buildout release is made, **the releaser** should update
+the bootstrap-release branch, too.
+
+The http://downloads.buildout.org/2/bootstrap.py location doesn't need to be
+updated manually: it is a redirect now, to
+https://bootstrap.pypa.io/bootstrap-buildout.py .

--- a/DEVELOPERS.txt
+++ b/DEVELOPERS.txt
@@ -50,3 +50,7 @@ the bootstrap-release branch, too.
 The http://downloads.buildout.org/2/bootstrap.py location doesn't need to be
 updated manually: it is a redirect now, to
 https://bootstrap.pypa.io/bootstrap-buildout.py .
+
+If there are changes to bootstrap.py, be sure to update the date in the
+``__version__`` attribute and to record the bootstrap change (including the
+new date/version) in zc.buildout's changelog.

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -95,7 +95,8 @@ if not options.allow_site_packages:
             # are not sys.prefix; this is because on Windows
             # sys.prefix is a site-package directory.
             if sitepackage_path != sys.prefix:
-                sys.path[:] = [x for x in sys.path if sitepackage_path not in x]
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
 
 setup_args = dict(to_dir=tmpeggs, download_delay=0)
 

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -75,12 +75,6 @@ try:
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
-if options.allow_site_packages:
-    try:
-        import setuptools
-        import pkg_resources
-    except ImportError:
-        pass
 
 ez = {}
 if os.path.exists('ez_setup.py'):

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -40,8 +40,9 @@ this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v", "--version", help="use a specific zc.buildout version")
-
+parser.add_option("-v",
+                  "--version",
+                  help="Use a specific zc.buildout version")
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -60,9 +61,9 @@ parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
 parser.add_option("--setuptools-version",
-                  help="use a specific setuptools version")
+                  help="Use a specific setuptools version")
 parser.add_option("--setuptools-to-dir",
-                  help=("allow for re-use of existing directory of "
+                  help=("Allow for re-use of existing directory of "
                         "setuptools versions"))
 
 options, args = parser.parse_args()

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -40,8 +40,7 @@ this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("-v",
-                  "--version",
+parser.add_option("--buildout-version",
                   help="Use a specific zc.buildout version")
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
@@ -139,7 +138,7 @@ if find_links:
     cmd.extend(['-f', find_links])
 
 requirement = 'zc.buildout'
-version = options.version
+version = options.buildout_version
 if version is None and not options.accept_buildout_test_releases:
     # Figure out the most recent final version of zc.buildout.
     import setuptools.package_index

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -74,6 +74,7 @@ parser.add_option("--setuptools-to-dir",
 options, args = parser.parse_args()
 if options.version:
     print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
 
 
 ######################################################################

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -72,12 +72,15 @@ options, args = parser.parse_args()
 # load/install setuptools
 
 try:
-    if options.allow_site_packages:
-        import setuptools
-        import pkg_resources
     from urllib.request import urlopen
 except ImportError:
     from urllib2 import urlopen
+if options.allow_site_packages:
+    try:
+        import setuptools
+        import pkg_resources
+    except ImportError:
+        pass
 
 ez = {}
 if os.path.exists('ez_setup.py'):

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -25,6 +25,9 @@ import tempfile
 
 from optparse import OptionParser
 
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
 tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
@@ -40,8 +43,9 @@ this script from going over the network.
 '''
 
 parser = OptionParser(usage=usage)
-parser.add_option("--buildout-version",
-                  help="Use a specific zc.buildout version")
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
 parser.add_option("-t", "--accept-buildout-test-releases",
                   dest='accept_buildout_test_releases',
                   action="store_true", default=False,
@@ -59,6 +63,8 @@ parser.add_option("-f", "--find-links",
 parser.add_option("--allow-site-packages",
                   action="store_true", default=False,
                   help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
 parser.add_option("--setuptools-version",
                   help="Use a specific setuptools version")
 parser.add_option("--setuptools-to-dir",
@@ -66,6 +72,9 @@ parser.add_option("--setuptools-to-dir",
                         "setuptools versions"))
 
 options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+
 
 ######################################################################
 # load/install setuptools

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -25,7 +25,7 @@ import tempfile
 
 from optparse import OptionParser
 
-tmpeggs = tempfile.mkdtemp()
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
 
 usage = '''\
 [DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]

--- a/src/zc/buildout/bootstrap.txt
+++ b/src/zc/buildout/bootstrap.txt
@@ -159,3 +159,16 @@ specify the setuptools version, and to reuse the setuptools zipfile.
       '/sample/eggs/setuptools-14.3...egg',
       '/sample/eggs/zc.buildout-2.0.0...egg',
       ]...
+
+You can ask bootstrap.py for its version. This is really the day the last
+change was made. A date leads to less confusion than a version number separate
+from buildout's own version number. Similarly, tracking buildout's version
+number leads to bootstraps with a new version number but without changes or to
+bootstraps with version number from an already-older buildout. So: a date is
+best.
+
+    >>> print_('X'); print_(system(
+    ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
+    ...     'bootstrap.py --version')); print_('X')
+    ... # doctest: +ELLIPSIS
+    X...2015...X

--- a/src/zc/buildout/bootstrap.txt
+++ b/src/zc/buildout/bootstrap.txt
@@ -59,14 +59,14 @@ By default it gets the latest version:
       '/sample/eggs/zc.buildout-22.0.0...egg',
       ]...
 
-Now trying the `--version` option, that let you define a version for
+Now trying the `--buildout-version` option, that let you define a version for
 `zc.buildout`.
 
 Let's try with an unknown version::
 
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
-    ...     'bootstrap.py --version UNKNOWN')); print_('X') # doctest: +ELLIPSIS
+    ...     'bootstrap.py --buildout-version UNKNOWN')); print_('X') # doctest: +ELLIPSIS
     ...
     X
     ...
@@ -77,7 +77,7 @@ Now let's try with `2.0.0`, which happens to exist::
 
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
-    ...     'bootstrap.py --version 2.0.0')); print_('X')
+    ...     'bootstrap.py --buildout-version 2.0.0')); print_('X')
     ... # doctest: +ELLIPSIS
     X...Generated script '/sample/bin/buildout'...X
 
@@ -115,7 +115,7 @@ which happens to exist::
 
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
-    ...     'bootstrap.py --setuptools-version 8.0 --version 2.0.0')); print_('X')
+    ...     'bootstrap.py --setuptools-version 8.0 --buildout-version 2.0.0')); print_('X')
     ... # doctest: +ELLIPSIS
     X...Generated script '/sample/bin/buildout'...X
 
@@ -145,7 +145,7 @@ specify the setuptools version, and to reuse the setuptools zipfile.
 
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
-    ...     'bootstrap.py --setuptools-version 14.3 --version 2.0.0 '+
+    ...     'bootstrap.py --setuptools-version 14.3 --buildout-version 2.0.0 '+
     ...     '--setuptools-to-dir .')); print_('X')
     ... # doctest: +ELLIPSIS
     X...Using local ez_setup.py...Generated script '/sample/bin/buildout'...X

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -391,6 +391,12 @@ class Buildout(DictMixin):
     def bootstrap(self, args):
         __doing__ = 'Bootstrapping.'
 
+        if os.path.exists(self['buildout']['develop-eggs-directory']):
+            if os.path.isdir(self['buildout']['develop-eggs-directory']):
+                rmtree(self['buildout']['develop-eggs-directory'])
+                self._logger.debug(
+                    "Removed existing develop-eggs directory")
+
         self._setup_directories()
 
         # Now copy buildout and setuptools eggs, and record destination eggs:
@@ -1444,9 +1450,9 @@ def _default_globals():
     These default expressions are convenience defaults available when eveluating
     section headers expressions.
     NB: this is wrapped in a function so that the computing of these expressions
-    is lazy and done only if needed (ie if there is at least one section with 
-    an expression) because the computing of some of these expressions can be 
-    expensive. 
+    is lazy and done only if needed (ie if there is at least one section with
+    an expression) because the computing of some of these expressions can be
+    expensive.
     """
     # partially derived or inspired from its.py
     # Copyright (c) 2012, Kenneth Reitz All rights reserved.

--- a/src/zc/buildout/buildout.txt
+++ b/src/zc/buildout/buildout.txt
@@ -2860,6 +2860,7 @@ or paths to use:
     >>> remove('setup.cfg')
     >>> print_(system(buildout + ' -csetup.cfg init demo other ./src'), end='')
     Creating '/sample-bootstrapped/setup.cfg'.
+    Creating directory '/sample-bootstrapped/develop-eggs'.
     Getting distribution for 'zc.recipe.egg>=2.0.0a3'.
     Got zc.recipe.egg
     Installing py.
@@ -2918,6 +2919,7 @@ for us:
     >>> remove('setup.cfg')
     >>> print_(system(buildout + ' -csetup.cfg init demo other ./src'), end='')
     Creating '/sample-bootstrapped/setup.cfg'.
+    Creating directory '/sample-bootstrapped/develop-eggs'.
     Installing py.
     Generated script '/sample-bootstrapped/bin/demo'.
     Generated script '/sample-bootstrapped/bin/distutilsscript'.

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -72,7 +72,7 @@ if has_distribute and not has_setuptools:
     sys.exit("zc.buildout 2 needs setuptools, not distribute."
              "  Are you using an outdated bootstrap.py?  Make sure"
              " you have the latest version downloaded from"
-             " http://downloads.buildout.org/2/bootstrap.py")
+             " https://bootstrap.pypa.io/bootstrap-buildout.py")
 
 setuptools_loc = pkg_resources.working_set.find(
     pkg_resources.Requirement.parse('setuptools')


### PR DESCRIPTION
Fixed bootstrap: a wrong combined try/except could lead to unintended breakage. In the end I removed the early import of setuptools altogether as it doesn't work well anymore with the newest ez_setup.py files.

The bootstrap phase of buildout itself now removes the develop-eggs directory first. I've grown tired of telling collegues to "remove the develop-eggs/ directory" when they have buildout problems. Some old bootstrap scripts could leave an incorrect `setuptools.egg-link` in there. Same with the `osc.recipe.sysegg` (there's a better version in `syseggrecipe` now that does the right thing). Anyway, removing the directory when bootstrapping is a good safety valve.