### PR TITLE
Buildout no longer breaks on packages with non-ascii filenames in them.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,11 @@ Unreleased
   higher for this functionality.
   [lrowe]
 
+- Buildout no longer breaks on packages that contain a file with a non-ascii
+  filename. Fixes #89 and #148.
+  [reinout]
+
+
 2.3.1 (2014-12-16)
 ==================
 

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1602,7 +1602,7 @@ def _open(base, filename, seen, dl_options, override, downloaded):
     return result
 
 
-ignore_directories = u'.svn', u'CVS', u'__pycache__'
+ignore_directories = '.svn', 'CVS', '__pycache__'
 _dir_hashes = {}
 def _dir_hash(dir):
     dir = fs_to_text(dir)
@@ -1613,13 +1613,13 @@ def _dir_hash(dir):
         return dir_hash
     hash = md5()
     for (dirpath, dirnames, filenames) in os.walk(dir):
-        dirnames = [fs_to_text(dirname) for dirname in dirnames]
-        filenames = [fs_to_text(filename) for filename in filenames]
+        dirnames[:] = [fs_to_text(dirname) for dirname in dirnames]
+        filenames[:] = [fs_to_text(filename) for filename in filenames]
         dirnames[:] = sorted(n for n in dirnames if n not in ignore_directories)
         filenames[:] = sorted(f for f in filenames
                               if (not (f.endswith('pyc') or f.endswith('pyo'))
                                   and os.path.exists(os.path.join(dirpath, f)))
-                              )
+                          )
         hash.update(' '.join(dirnames).encode('utf-8'))
         hash.update(' '.join(filenames).encode('utf-8'))
         for name in filenames:

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##############################################################################
 #
 # Copyright (c) 2004-2009 Zope Foundation and Contributors.
@@ -1153,6 +1154,20 @@ because of the missing target file.
     >>> print_(system(join(sample_buildout, 'bin', 'buildout')), end='')
     Develop: '/sample-buildout/recipe'
     Updating foo.
+
+    """
+
+def unicode_filename_doesnt_break_hash():
+    """
+Buildout's _dir_hash() used to break on non-ascii filenames.
+
+    >>> mkdir('héhé')
+    >>> write('héhé', 'héhé.py',
+    ... '''
+    ... print('Example filename from pyramid tests')
+    ... ''')
+    >>> from zc.buildout.buildout import _dir_hash
+    >>> _dir_hash('héhé')
 
     """
 

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -1159,7 +1159,7 @@ because of the missing target file.
 
 def unicode_filename_doesnt_break_hash():
     """
-Buildout's _dir_hash() used to break on non-ascii filenames.
+Buildout's _dir_hash() used to break on non-ascii filenames on python 2.
 
     >>> mkdir('héhé')
     >>> write('héhé', 'héhé.py',
@@ -1167,7 +1167,7 @@ Buildout's _dir_hash() used to break on non-ascii filenames.
     ... print('Example filename from pyramid tests')
     ... ''')
     >>> from zc.buildout.buildout import _dir_hash
-    >>> _dir_hash('héhé')
+    >>> dont_care = _dir_hash('héhé')
 
     """
 


### PR DESCRIPTION
Fixes #89 and #148.

The error only occurred on python 2, python 3 is fine. The main cause:

`os.walk()` would return filenames as non-ascii bytestrings. A `' '.join()` would fail with an error. (Or the subsequent `.encode()` call, I don't remember which of the two was an error. We now convert all filenames to unicode. The same approach is used by zest.releaser and it works fine there.

Additionally, the md5 `hash.update()` would fail with non-ascii characters. There's now an explicit call to `.encode('utf-8')`, just like with the file contents, which we already assumed could be non-ascii.

The tests run on both 2 and 3. The original test case failed on 2.x and ran just fine on 3.x the first time it ran on travis.ci, nicely demonstrating that it worked fine on python 3.

Note that there was initially an error in my implementation which was caught just fine by the test case. So the test coverage in this area is pretty good :-)