### PR TITLE
Enable downloading behind a proxy by using urllib2

### DIFF
--- a/src/zc/buildout/download.py
+++ b/src/zc/buildout/download.py
@@ -24,10 +24,10 @@ try:
     from urllib.parse import urlparse
     from urllib import request
 
-    class URLOpener(FancyURLopener):
+    class PatchedURLopener(FancyURLopener):
         http_error_default = URLopener.http_error_default
 
-    request._urlopener = URLOpener()  # Ook! Monkey patch!
+    request._urlopener = PatchedURLopener()  # Ook! Monkey patch!
 
 except ImportError:
     # Python 2


### PR DESCRIPTION
Behind a proxy, `urllib` does not work with Python2 due to [Python issue
24599](https://bugs.python.org/issue24599).

Instead of using `urllib`, let's implement `urlretrieve` with `urllib2`, which
instead works and leave the Python3 implementation untouched (since that
one works too).

This fixes buildout issue #32.

There's no need to change the `try: except:IOError` block where `urlretrieve` is
used (line 195 in download.py) since the exceptions raised by `urllib2`
are subclasses of `IOError` and will then be caught.