### PR TITLE
Check the 'use-dependency-links' option earlier.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 2.4.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Check the ``use-dependency-links`` option earlier.  This can give
+  a small speed increase.
+  [maurits]
 
 
 2.4.0 (2015-07-01)

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -552,18 +552,18 @@ class Installer:
         else:
             dists = [dist]
 
-        for dist in dists:
-            if (dist.has_metadata('dependency_links.txt')
-                and not self._install_from_cache
-                and self._use_dependency_links
-                ):
-                for link in dist.get_metadata_lines('dependency_links.txt'):
-                    link = link.strip()
-                    if link not in self._links:
-                        logger.debug('Adding find link %r from %s', link, dist)
-                        self._links.append(link)
-                        self._index = _get_index(self._index_url, self._links,
-                                                 self._allow_hosts)
+        if not self._install_from_cache and self._use_dependency_links:
+            for dist in dists:
+                if dist.has_metadata('dependency_links.txt'):
+                    for link in dist.get_metadata_lines('dependency_links.txt'):
+                        link = link.strip()
+                        if link not in self._links:
+                            logger.debug('Adding find link %r from %s',
+                                         link, dist)
+                            self._links.append(link)
+                            self._index = _get_index(self._index_url,
+                                                     self._links,
+                                                     self._allow_hosts)
 
         for dist in dists:
             # Check whether we picked a version and, if we did, report it:


### PR DESCRIPTION
This can give a small speed increase.

Before this, for each dist we would first check if it had a dependency links option, which is almost always the case, but it is usually empty: the package *will* have a dependency_links.txt in its EGG-INFO, but there is only an empty line in it.

When you have a lot of packages and several buildout parts that use them, the dependency links can be checked a lot of times.

On an extended Plone buildout with `use-dependency-links=false`, where get_dist was called over 2500 times, the difference was 0.1 seconds, so not much.  When I/O is slow, the difference could be more noticeable.

Note that actually setting `use-dependency-links` to false, already helps much more.  For this buildout it shaved off 1.5 seconds.

Note that the 0.1 seconds win is because we do not have to call 'os.exists' for all those files, and the 1.5 seconds win is because we do not have to actually read those files.

Also, for completeness sake, note that in this buildout `_get_dist` was called lots of times, but the list of dists that we checked for dependency links in this method was always just a list of one.  So we could have simply switched the order of the three parts of the condition around with the same effect (and a smaller diff).  Still, the way I did it now seems better.

And I am probably explaining myself much much more than is needed. :-)