### PR TITLE
A MissingSectionHeader error now also reports the cached file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 2.4.2 (unreleased)
 ==================
 
-- Nothing changed yet.
+- If a downloaded config file in the "extends-cache" gets corrupted, buildout
+  now tells you the filename in the cache. Handy for troubleshooting.
+  [reinout]
 
 
 2.4.1 (2015-08-08)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1601,7 +1601,7 @@ def _open(base, filename, seen, dl_options, override, downloaded):
 
     filename_for_logging = filename
     if downloaded_filename:
-        filename_for_logging = '%s (cached at %s)' % (
+        filename_for_logging = '%s (downloaded as %s)' % (
             filename, downloaded_filename)
     result = zc.buildout.configparser.parse(
         fp, filename_for_logging, _default_globals)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1570,10 +1570,10 @@ def _open(base, filename, seen, dl_options, override, downloaded):
         _dl_options, cache=_dl_options.get('extends-cache'),
         fallback=fallback, hash_name=True)
     is_temp = False
-    cached_filename = None
+    downloaded_filename = None
     if _isurl(filename):
-        cached_filename, is_temp = download(filename)
-        fp = open(cached_filename)
+        downloaded_filename, is_temp = download(filename)
+        fp = open(downloaded_filename)
         base = filename[:filename.rfind('/')]
     elif _isurl(base):
         if os.path.isabs(filename):
@@ -1581,8 +1581,8 @@ def _open(base, filename, seen, dl_options, override, downloaded):
             base = os.path.dirname(filename)
         else:
             filename = base + '/' + filename
-            cached_filename, is_temp = download(filename)
-            fp = open(cached_filename)
+            downloaded_filename, is_temp = download(filename)
+            fp = open(downloaded_filename)
             base = filename[:filename.rfind('/')]
     else:
         filename = os.path.join(base, filename)
@@ -1593,21 +1593,22 @@ def _open(base, filename, seen, dl_options, override, downloaded):
     if filename in seen:
         if is_temp:
             fp.close()
-            os.remove(cached_filename)
+            os.remove(downloaded_filename)
         raise zc.buildout.UserError("Recursive file include", seen, filename)
 
     root_config_file = not seen
     seen.append(filename)
 
     filename_for_logging = filename
-    if cached_filename:
-        filename_for_logging = '%s (cached at %s)' % (filename, cached_filename)
+    if downloaded_filename:
+        filename_for_logging = '%s (cached at %s)' % (
+            filename, downloaded_filename)
     result = zc.buildout.configparser.parse(
         fp, filename_for_logging, _default_globals)
 
     fp.close()
     if is_temp:
-        os.remove(cached_filename)
+        os.remove(downloaded_filename)
 
     options = result.get('buildout', {})
     extends = options.pop('extends', None)

--- a/src/zc/buildout/extends-cache.txt
+++ b/src/zc/buildout/extends-cache.txt
@@ -267,7 +267,7 @@ Clean up:
 >>> rmdir('cache')
 
 Offline mode and installation from cache
-----------------------------~~~~~~~~~~~~
+----------------------------------------
 
 If we run buildout in offline mode now, it will fail because it cannot get at
 the remote configuration file needed by the user's defaults:
@@ -503,6 +503,30 @@ UserError is raised if that option is encountered now:
 While:
   Initializing.
 Error: No-longer supported "extended-by" option found in http://localhost/base.cfg.
+
+
+Reporting cached locations for downloads of faulty config files
+---------------------------------------------------------------
+
+A downloaded config file might be invalid. A cancelled buildout run, an
+accidentally gzip-encoded download and so on.
+
+>>> write(server_data, 'faulty.cfg', """\
+... This is definitively not
+... a proper() config file.
+... """)
+
+>>> write('buildout.cfg', """\
+... [buildout]
+... extends = %sfaulty.cfg
+... """ % server_url)
+>>> print_(system(buildout))
+While:
+  Initializing.
+...
+MissingSectionHeaderError: File contains no section headers.
+file: http://localhost/faulty.cfg (cached at ...), line: 1
+'This is definitively not\n'
 
 
 Clean up

--- a/src/zc/buildout/extends-cache.txt
+++ b/src/zc/buildout/extends-cache.txt
@@ -523,8 +523,7 @@ accidentally gzip-encoded download and so on.
 >>> print_(system(buildout))
 While:
   Initializing.
-...
-MissingSectionHeaderError: File contains no section headers.
+... File contains no section headers.
 file: http://localhost/faulty.cfg (cached at ...), line: 1
 'This is definitively not\n'
 

--- a/src/zc/buildout/extends-cache.txt
+++ b/src/zc/buildout/extends-cache.txt
@@ -524,7 +524,7 @@ accidentally gzip-encoded download and so on.
 While:
   Initializing.
 ... File contains no section headers.
-file: http://localhost/faulty.cfg (cached at ...), line: 1
+file: http://localhost/faulty.cfg (downloaded as ...), line: 1
 'This is definitively not\n'
 
 


### PR DESCRIPTION
Fixes #245 mostly.

The error now prints the cached location of the downloaded file, making it much easier to clean up downloads that went wrong.