### PR TITLE
Disabled patching of FancyURLopener in the download.py if used Python>=3.3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,13 @@ Change History
 2.4.4 (unreleased)
 ==================
 
-- Added support for Python>=3.3 into the download.py.
+- Disabled patching of FancyURLopener in the download.py if used Python>=3.3.
 
 
 2.4.3 (2015-09-03)
 ==================
 
-- Added nested directory creation support 
+- Added nested directory creation support
   [guyzmo]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change History
 2.4.4 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added support for Python>=3.3 into the download.py.
 
 
 2.4.3 (2015-09-03)

--- a/src/zc/buildout/download.py
+++ b/src/zc/buildout/download.py
@@ -25,12 +25,9 @@ try:
     from urllib.parse import urlparse
     from urllib import request
 
-    class PatchedURLopener(FancyURLopener):
-        http_error_default = URLopener.http_error_default
-
-    if sys.version_info[:2] >= (3, 3):
-        request.install_opener(PatchedURLopener())
-    else:
+    if sys.version_info[:2] < (3, 3):
+        class PatchedURLopener(FancyURLopener):
+            http_error_default = URLopener.http_error_default
         request._urlopener = PatchedURLopener()  # Ook! Monkey patch!
 
 except ImportError:

--- a/src/zc/buildout/download.py
+++ b/src/zc/buildout/download.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Buildout download infrastructure"""
 
+import sys
 try:
     from hashlib import md5
 except ImportError:
@@ -27,7 +28,10 @@ try:
     class PatchedURLopener(FancyURLopener):
         http_error_default = URLopener.http_error_default
 
-    request._urlopener = PatchedURLopener()  # Ook! Monkey patch!
+    if sys.version_info[:2] >= (3, 3):
+        request.install_opener(PatchedURLopener())
+    else:
+        request._urlopener = PatchedURLopener()  # Ook! Monkey patch!
 
 except ImportError:
     # Python 2


### PR DESCRIPTION
Starting with version Python 3.3 the module **urllib.request** no longer contains the global variable **_urlopener**.