### PR TITLE
fix for win32 '#!"python"' vs '#!python' shebang

### DIFF
--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3539,6 +3539,10 @@ def test_suite():
                  "Unused options for buildout: 'scripts' 'eggs'."),
                 # Python 3.4 changed the wording of NameErrors
                 (re.compile('NameError: global name'), 'NameError: name'),
+                # fix for test_distutils_scripts_using_import_are_properly_parsed
+                # and test_distutils_scripts_using_from_are_properly_parsed
+                # win32 apparently adds a " around sys.executable
+                (re.compile('#!"python"'), '#!python'),
                 ]),
             ),
         zc.buildout.rmtree.test_suite(),


### PR DESCRIPTION
fixes the 2 failures at

http://winbot.zope.org/builders/zc_buildout_dev%20py_270_win32%20master/builds/1144/steps/test/logs/stdio