### PR TITLE
Upgraded version pins

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,8 +4,10 @@ parts = test oltest py
 versions = versions
 
 [versions]
-zope.interface = 4.0.1
-zope.exceptions = 4.0.1
+zope.interface = 4.1.3
+zope.exceptions = 4.0.8
+zc.recipe.testrunner = 2.0.0
+zope.testing = 4.5.0
 
 [py]
 recipe = zc.recipe.egg
@@ -15,7 +17,7 @@ eggs = zc.buildout
 interpreter = py
 
 [test]
-recipe = zc.recipe.testrunner ==1.3.0
+recipe = zc.recipe.testrunner
 eggs =
   zc.buildout[test]
   zc.recipe.egg
@@ -31,4 +33,3 @@ defaults =
   '-t',
   '!(bootstrap|selectingpython|selecting-python)',
   ]
-


### PR DESCRIPTION
This only impacts testing.
Note that

    VersionConflict: (zc.recipe.testrunner 2.0.0 (/Users/reinout/.buildout/eggs/zc.recipe.testrunner-2.0.0-py2.7.egg), Requirement.parse('zc.recipe.testrunner==1.3.0'))

means you have to remove .installed.cfg. Pinning a recipe version in a 'recipe=' line isn't handy.