### PR TITLE
In the tests, filter out an invisible control character.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change History
 2.5.3 (unreleased)
 ==================
 
+- In ``zc.buildout.testing.system``, set ``TERM=dumb`` in the environment.
+  This avoids invisible control characters popping up in some terminals,
+  like ``xterm``.  Note that this may affect tests by buildout recipes.
+  [maurits]
+
 - Removed Python 2.6 and 3.2 support.
   [do3cc]
 

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -110,12 +110,18 @@ def clean_up_pyc(*path):
 MUST_CLOSE_FDS = not sys.platform.startswith('win')
 
 def system(command, input='', with_exit_code=False):
+    # Some TERMinals, expecially xterm and its variants, add invisible control
+    # characters, which we do not want as they mess up doctests.  See:
+    # https://github.com/buildout/buildout/pull/311
+    # http://bugs.python.org/issue19884
+    env = dict(os.environ, TERM='dumb')
     p = subprocess.Popen(command,
                          shell=True,
                          stdin=subprocess.PIPE,
                          stdout=subprocess.PIPE,
                          stderr=subprocess.PIPE,
-                         close_fds=MUST_CLOSE_FDS)
+                         close_fds=MUST_CLOSE_FDS,
+                         env=env)
     i, o, e = (p.stdin, p.stdout, p.stderr)
     if input:
         i.write(input.encode())


### PR DESCRIPTION
I am getting a few test failure on my laptop.  Mac OSX 10.11.6.

The first one is this, made clearer by adding `doctest: +REPORT_UDIFF`:

```
File ".../src/zc/buildout/debugging.txt", line 70, in debugging.txt
Failed example:
    print_(system(buildout+" -D", """\
    up
    p sorted(self.options.keys())
    q
    """), end='')  # doctest: +REPORT_UDIFF
Differences (unified diff with -expected +actual):
    @@ -1,5 +1,5 @@
     Develop: '/sample-buildout/recipes'
     Installing data-dir.
    -> buildout.py(NNN)__getitem__()
    +> buildout.py(NNN)__getitem__()
     -> raise MissingOption("Missing option: %s:%s" % (self.name, key))
     (Pdb) > /sample-buildout/recipes/mkdir.py(NNN)install()
```

It looks like no real difference. When inspecting this, it turns out that I get a few special characters at the front of the line:

```
Installing data-dir.\n\x1b[?1034h> /.../src/zc/buildout/buildout.py(1369)__getitem__()\
```

This could be fixed this by adding ellipsis in the doctest in front of that line.

The second test that goes wrong is this one:

```
File "/.../zc/recipe/egg/README.rst", line 215, in README.rst
Failed example:
    print_(system(join(sample_buildout, 'bin', 'py-demo'),
    """import os, sys
    for p in sys.path:
        if 'demo' in p:
            _ = sys.stdout.write(os.path.basename(p)+'\\n')

    """).replace('>>> ', '').replace('... ', ''), end='')
    # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
Expected:
    demo-0.2-pyN.N.egg
    demoneeded-1.1-pyN.N.egg
Got:
    demo-0.2-pyN.N.egg
    demoneeded-1.1-pyN.N.egg
    <BLANKLINE>
    <BLANKLINE>
```

That one also looks strange, as the extra blank lines should be handled just fine by the normalize whitespace.  This turns out to be the same problem as the first one.  The string is:

```
\x1b[?1034hdemo-0.2-py2.7.egg\ndemoneeded-1.1-py2.7.egg\n\n\n
```

Adding ellipsis here is tricky because it is needed on the first line, which would confuse the doctest into thinking it is part of the command that should be executed.

According to this page, this is a control character that sets the 8-bit input mode:
http://stackoverflow.com/questions/21135991/

It may be better to strip this character sequence in the `print_` function:

```
def print_(*args, **kw):
    sep, end, file = _print_options(**kw)
    if file is None:
        file = sys.stdout
    result = sep.join(map(str, args))+end
    # This might contain an invisible control character '\x1b[?1034h'
    # which is very annoying when comparing output in doctests:
    # a difference is reported but you don't see it.
    # So we remove it.
    result = result.replace('\x1b[?1034h', '')
    file.write(result)
```

But this may have unwanted effects in real buildout runs, instead of only helping in the tests.  So in the end I decided to fix it in the regular expressions in the tests.
Note that one of the changes is in zc.recipe.egg, so this would need another release eventually.
