### PR TITLE
Fixes #326

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Change History
 2.7.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fixed a bug introduced in 2.6.0:
+  zc.buildout and its dependeoncies were reported as picked even when
+  their versions were fixed in a ``versions`` section.  Worse, when the
+  ``update-versions-file`` option was used, the ``versions`` section was
+  updated needlessly on every run.
 
 
 2.7.0 (2017-01-30)

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -188,7 +188,8 @@ class Installer:
                  newest=True,
                  versions=None,
                  use_dependency_links=None,
-                 allow_hosts=('*',)
+                 allow_hosts=('*',),
+                 check_picked=True,
                  ):
         assert executable == sys.executable, (executable, sys.executable)
         self._dest = dest
@@ -218,6 +219,7 @@ class Installer:
         self._env = pkg_resources.Environment(path)
         self._index = _get_index(index, links, self._allow_hosts)
         self._requirements_and_constraints = []
+        self._check_picked = check_picked
 
         if versions is not None:
             self._versions = normalize_versions(versions)
@@ -558,7 +560,7 @@ class Installer:
                                                      self._links,
                                                      self._allow_hosts)
 
-        if self._dest is not None:
+        if self._check_picked:
             # Check whether we picked a version and, if we did, report it:
             for dist in dists:
                 if not (
@@ -877,6 +879,7 @@ def install(specs, dest,
             use_dependency_links=None, allow_hosts=('*',),
             include_site_packages=None,
             allowed_eggs_from_site_packages=None,
+            check_picked=True,
             ):
     assert executable == sys.executable, (executable, sys.executable)
     assert include_site_packages is None
@@ -885,14 +888,16 @@ def install(specs, dest,
     installer = Installer(dest, links, index, sys.executable,
                           always_unzip, path,
                           newest, versions, use_dependency_links,
-                          allow_hosts=allow_hosts)
+                          allow_hosts=allow_hosts,
+                          check_picked=check_picked)
     return installer.install(specs, working_set)
 
-buildout_and_setuptools_dists = list(install(['zc.buildout'], None))
+buildout_and_setuptools_dists = list(install(['zc.buildout'], None,
+                                             check_picked=False))
 buildout_and_setuptools_path = [d.location
                                 for d in buildout_and_setuptools_dists]
 setuptools_path = [d.location
-                   for d in install(['setuptools'], None)]
+                   for d in install(['setuptools'], None, check_picked=False)]
 setuptools_pythonpath = os.pathsep.join(setuptools_path)
 
 def build(spec, dest, build_ext,

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -558,23 +558,25 @@ class Installer:
                                                      self._links,
                                                      self._allow_hosts)
 
-        for dist in dists:
+        if self._dest is not None:
             # Check whether we picked a version and, if we did, report it:
-            if not (
-                dist.precedence == pkg_resources.DEVELOP_DIST
-                or
-                (len(requirement.specs) == 1
-                 and
-                 requirement.specs[0][0] == '==')
-                ):
-                logger.debug('Picked: %s = %s',
-                             dist.project_name, dist.version)
-                self._picked_versions[dist.project_name] = dist.version
+            for dist in dists:
+                if not (
+                    dist.precedence == pkg_resources.DEVELOP_DIST
+                    or
+                    (len(requirement.specs) == 1
+                     and
+                     requirement.specs[0][0] == '==')
+                    ):
+                    logger.debug('Picked: %s = %s',
+                                 dist.project_name, dist.version)
+                    self._picked_versions[dist.project_name] = dist.version
 
-                if not self._allow_picked_versions:
-                    raise zc.buildout.UserError(
-                        'Picked: %s = %s' % (dist.project_name, dist.version)
-                        )
+                    if not self._allow_picked_versions:
+                        raise zc.buildout.UserError(
+                            'Picked: %s = %s' % (dist.project_name,
+                                                 dist.version)
+                            )
 
         return dists
 

--- a/src/zc/buildout/repeatable.txt
+++ b/src/zc/buildout/repeatable.txt
@@ -420,10 +420,8 @@ The versions file now contains the extra pin:
 
 And re-running buildout doesn't report any picked versions anymore:
 
-    >>> print_(system(buildout), end='') # doctest: +ELLIPSIS
-    Updating foo.
-    recipe v2
-    ...
+    >>> 'picked' in system(buildout)
+    False
 
 If you've enabled ``update-versions-file`` but not ``show-picked-versions``,
 buildout will append the versions to your versions file anyway (without

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3082,17 +3082,23 @@ def test_buildout_doesnt_keep_adding_itself_to_versions():
     >>> with open('versions.cfg') as f:
     ...     versions = f.read()
     >>> _ = system(join('bin', 'buildout'))
-    >>> _ = system(join('bin', 'buildout'))
-    >>> _ = system(join('bin', 'buildout'))
-    >>> with open('versions.cfg') as f:
-    ...     versions == f.read()
-    True
+
+    On the first run, some pins were added:
+
     >>> cat('versions.cfg') # doctest: +ELLIPSIS
     [versions]
     <BLANKLINE>
     # Added by buildout...
     setuptools = 34.0.3
     ...
+    >>> _ = system(join('bin', 'buildout'))
+    >>> _ = system(join('bin', 'buildout'))
+
+    Subsequent runs didn't add additional text:
+
+    >>> with open('versions.cfg') as f:
+    ...     versions == f.read()
+    True
     """
 
 if sys.platform == 'win32':

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -2408,12 +2408,12 @@ def wont_downgrade_due_to_prefer_final():
     ... parts =
     ... ''')
 
-    >>> [v] = [str(l.split('= >=', 1)[1].strip())
+    >>> [v] = [l.split('= >=', 1)[1].strip()
     ...        for l in system(buildout+' -vv').split('\n')
     ...        if l.startswith('zc.buildout = >=')]
-    >>> v == str(pkg_resources.working_set.find(
+    >>> v == pkg_resources.working_set.find(
     ...         pkg_resources.Requirement.parse('zc.buildout')
-    ...         ).version)
+    ...         ).version
     True
 
     >>> write('buildout.cfg',


### PR DESCRIPTION
Fixed a bug introduced in 2.6.0:
zc.buildout and its dependeoncies were reported as picked even when
their versions were fixed in a ``versions`` section.  Worse, when the
``update-versions-file`` option was used, the ``versions`` section was
updated needlessly on every run.