### PR TITLE
Installer: Encapsulate all uses of `._env` and `._path`

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -25,9 +25,7 @@ eggs =
 # Tests that can be run wo a network
 [oltest]
 recipe = zc.recipe.testrunner
-eggs =
-  zc.buildout[test]
-  zc.recipe.egg
+eggs = ${test:eggs}
 defaults =
   [
   '-t',

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3191,8 +3191,7 @@ class UnitTests(unittest.TestCase):
         def wheel_to_egg(dist, dest):
             newloc = os.path.join(dest, egg_name)
             shutil.copy(dist.location, newloc)
-            return pkg_resources.Distribution.from_location(newloc,
-                                                            'demo-0.3.whl')
+            return pkg_resources.Distribution.from_filename(newloc)
         zc.buildout.easy_install.wheel_to_egg = wheel_to_egg
         egg_dir = os.path.join(self.sample_buildout, 'eggs')
         self.assertFalse(egg_name in os.listdir(egg_dir))


### PR DESCRIPTION
All write access to `easy_install.Installer._env` and all access to `easy_install.Installer._path` are now done through `easy_install.Installer` methods, so that buildout extensions can install subclasses that alter their behaviour.