### PR TITLE
easy_install: moar loggin' for fetchin'

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -466,8 +466,10 @@ class Installer:
         if (download_cache
             and (realpath(os.path.dirname(dist.location)) == download_cache)
             ):
+            logger.debug("Download cache has %s at: %s", dist, dist.location)
             return dist
 
+        logger.debug("Fetching %s from: %s", dist, dist.location)
         new_location = self._index.download(dist.location, tmp)
         if (download_cache
             and (realpath(new_location) == realpath(dist.location))

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -266,6 +266,8 @@ reporting that a version was picked automatically:
       Installing 'demo'.
     zc.buildout.easy_install INFO
       Getting distribution for 'demo'.
+    zc.buildout.easy_install DEBUG
+      Fetching demo 0.3 from: http://.../demo-0.3-pyN.N.egg
     zc.buildout.easy_install INFO
       Got demo 0.3.
     zc.buildout.easy_install DEBUG
@@ -276,6 +278,8 @@ reporting that a version was picked automatically:
         required by demo 0.3.
     zc.buildout.easy_install INFO
       Getting distribution for 'demoneeded'.
+    zc.buildout.easy_install DEBUG
+      Fetching demoneeded 1.1 from: http://.../demoneeded-1.1.zip
     zc.buildout.easy_install DEBUG
       Running easy_install:...
     zc.buildout.easy_install INFO


### PR DESCRIPTION
Make it clear from where we're fetching a dist that we don't have installed, reporting the specific URL or the path from inside the download cache.

