### PR TITLE
Meta recipes

### DIFF
--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -10,5 +10,6 @@ Buildout Topics
    optimizing
    bootstrapping
    writing-recipes
+   meta-recipes
 
 .. todo:

--- a/doc/topics/meta-recipes.rst
+++ b/doc/topics/meta-recipes.rst
@@ -1,6 +1,6 @@
-Meta-recipe support
-===================
-
+============
+Meta-recipes
+============
 
 Buildout recipes provide reusable Python modules for common
 configuration tasks. The most widely used recipes tend to provide
@@ -179,7 +179,7 @@ There are a few things to note about this example:
 - An exception will be raised if a section already exists.
 
 Testing
--------
+=======
 
 Now, let's test our meta recipe.  We'll test it without actually
 running buildout. Rather, we'll use a specialized buildout provided by
@@ -196,7 +196,7 @@ tested:
 After running the recipe, we should see the buildout database
 populated by the recipe:
 
-    >>> buildout.print_options()
+    >>> buildout.print_options(base_path='/sample-buildout')
     [ctl]
     chkconfig = 345 99 10
     deployment = deployment

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ long_description=(
         + '\n' +
         read('src', 'zc', 'buildout', 'debugging.txt')
         + '\n' +
-        read('src', 'zc', 'buildout', 'meta-recipes.txt')
-        + '\n' +
         read('src', 'zc', 'buildout', 'testing.txt')
         + '\n' +
         read('src', 'zc', 'buildout', 'easy_install.txt')

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1108,7 +1108,7 @@ class Buildout(DictMixin):
     def annotate(self, args=None):
         _print_annotate(self._annotated)
 
-    def print_options(self):
+    def print_options(self, base_path=None):
         for section in sorted(self._data):
             if section == 'buildout' or section == self['buildout']['versions']:
                 continue
@@ -1118,6 +1118,9 @@ class Buildout(DictMixin):
                     v = '\n  ' + v.replace('\n', '\n  ')
                 else:
                     v = ' '+v
+
+                if base_path:
+                    v = v.replace(os.getcwd(), base_path)
                 print_("%s =%s" % (k, v))
 
     def __getitem__(self, section):

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -187,8 +187,11 @@ class TestOptions(zc.buildout.buildout.Options):
 class Buildout(zc.buildout.buildout.Buildout):
 
     def __init__(self):
+        for name in 'eggs', 'parts':
+            if not os.path.exists(name):
+                os.mkdir(name)
         zc.buildout.buildout.Buildout.__init__(
-            self, '', [('buildout', 'directory', os.getcwd())])
+            self, '', [('buildout', 'directory', os.getcwd())], False)
 
     Options = TestOptions
 

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3553,7 +3553,7 @@ def test_suite():
                      'zc.\1 = >=1.99'),
                     ])
                 ) + manuel.capture.Manuel(),
-            'buildout.txt', 'meta-recipes.txt',
+            'buildout.txt',
             setUp=buildout_txt_setup,
             tearDown=zc.buildout.testing.buildoutTearDown,
             ),
@@ -3831,7 +3831,9 @@ def test_suite():
 
         test_suite.append(
             manuel.testing.TestSuite(
-                manuel.doctest.Manuel() + manuel.capture.Manuel(),
+                manuel.doctest.Manuel(
+                    optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
+                    ) + manuel.capture.Manuel(),
                 os.path.join(docdir, 'getting-started.rst'),
                 os.path.join(docdir, 'reference.rst'),
                 os.path.join(docdir, 'topics', 'bootstrapping.rst'),
@@ -3840,6 +3842,7 @@ def test_suite():
                     'topics', 'variables-extending-and-substitutions.rst'),
                 os.path.join(docdir, 'topics', 'writing-recipes.rst'),
                 os.path.join(docdir, 'topics', 'optimizing.rst'),
+                os.path.join(docdir, 'topics', 'meta-recipes.rst'),
                 setUp=docSetUp, tearDown=setupstack.tearDown
                 ))
 


### PR DESCRIPTION
This just moves the existing documentation from the buildout package into the manual.

The original test was written as documentation using manuel.