### PR TITLE
Drop use of pkg_resources._by_version_descending()

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -289,8 +289,7 @@ class Installer:
         eggs = glob.glob(os.path.join(dest, '*.egg'))
         dists = [os.path.dirname(dist_info) for dist_info in
                  glob.glob(os.path.join(dest, '*', '*.dist-info'))]
-        # sort them like pkg_resources.find_on_path() would
-        return pkg_resources._by_version_descending(set(eggs + dists))
+        return list(set(eggs + dists))
 
     @staticmethod
     def _eggify_env_dest_dists(env, dest):


### PR DESCRIPTION
It's not present in older setuptools versions.

It seems not to be needed since `pkg_resources.Environment.add()` will
sort dists in each project_name according to their version anyway.

Fix: #375