### PR TITLE
Respect index url and links when installing setup-required dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Change History
 2.9.4 (unreleased)
 ==================
 
-- Nothing changed yet.
-
+- Respect index-url and find-links when calling easy install for
+  setup-required dependencies.
 
 2.9.3 (2017-03-30)
 ==================

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1593,11 +1593,11 @@ def call_easy_install(spec, dest, index=None, links=None):
         '-mZUNx']
 
     if index is not None:
-        args.append('--index-url=' + index)
+        args.extend(['-i', index])
 
     if links is not None:
         for link in links:
-            args.append('--find-links=' + link)
+            args.extend(['-f', link])
 
     args.extend(['-d', dest])
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -406,10 +406,10 @@ class Installer:
         return best_we_have, None
 
     def _call_easy_install(self, spec, dest, dist):
-
         tmp = tempfile.mkdtemp(dir=dest)
         try:
-            paths = call_easy_install(spec, tmp)
+            paths = call_easy_install(
+                spec, tmp, index=self._index_url, links=self._links)
 
             dists = []
             env = pkg_resources.Environment(paths)
@@ -560,7 +560,10 @@ class Installer:
                     raise zc.buildout.UserError(
                         "Couldn't download distribution %s." % avail)
 
-                dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
+                dists = [
+                    _move_to_eggs_dir_and_compile(
+                        dist, self._dest,
+                        index=self._index_url, links=self._links)]
 
             finally:
                 if tmp != self._download_cache:
@@ -732,7 +735,6 @@ class Installer:
         return ws
 
     def build(self, spec, build_ext):
-
         requirement = self._constrain(pkg_resources.Requirement.parse(spec))
 
         dist, avail = self._satisfied(requirement, 1)
@@ -1576,7 +1578,7 @@ class IncompatibleConstraintError(zc.buildout.UserError):
 IncompatibleVersionError = IncompatibleConstraintError # Backward compatibility
 
 
-def call_easy_install(spec, dest):
+def call_easy_install(spec, dest, index=None, links=None):
     """
     Call `easy_install` from setuptools as a subprocess to install a
     distribution specified by `spec` into `dest`.
@@ -1584,9 +1586,21 @@ def call_easy_install(spec, dest):
     """
     path = setuptools_path
 
-    args = [sys.executable, '-c',
-            ('import sys; sys.path[0:0] = %r; ' % path) +
-            _easy_install_cmd, '-mZUNxd', dest]
+    args = [
+        sys.executable,
+        '-c',
+        ('import sys; sys.path[0:0] = %r; ' % path) + _easy_install_cmd,
+        '-mZUNx']
+
+    if index is not None:
+        args.append('--index-url=' + index)
+
+    if links is not None:
+        for link in links:
+            args.append('--find-links=' + link)
+
+    args.extend(['-d', dest])
+
     level = logger.getEffectiveLevel()
     if level > 0:
         args.append('-q')
@@ -1637,7 +1651,7 @@ def unpack_wheel(location, dest):
     [egg] = glob.glob(os.path.join(tmp_dest, '*.egg'))
     unpack_egg(egg, dest)
     shutil.rmtree(tmp_dest)
-    
+
 
 UNPACKERS = {
     '.egg': unpack_egg,
@@ -1659,7 +1673,7 @@ def _get_matching_dist_in_location(dist, location):
     if dist_infos == [(dist.project_name, dist.version)]:
         return dists.pop()
 
-def _move_to_eggs_dir_and_compile(dist, dest):
+def _move_to_eggs_dir_and_compile(dist, dest, index=None, links=None):
     """Move distribution to the eggs destination directory.
 
     And compile the py files, if we have actually moved the dist.
@@ -1694,8 +1708,12 @@ def _move_to_eggs_dir_and_compile(dist, dest):
             # It is an archive of some sort.
             # Figure out how to unpack it, or fall back to easy_install.
             _, ext = os.path.splitext(dist.location)
-            unpacker = UNPACKERS.get(ext, call_easy_install)
-            unpacker(dist.location, tmp_dest)
+            unpacker = UNPACKERS.get(ext, None)
+            if unpacker is None:
+                call_easy_install(
+                    dist.location, tmp_dest, index=index, links=links)
+            else:
+                unpacker(dist.location, tmp_dest)
             [tmp_loc] = glob.glob(os.path.join(tmp_dest, '*'))
 
         # We have installed the dist. Now try to rename/move it.


### PR DESCRIPTION
In our use-case we allow installing package only through our own package index (proxying pypi for public package and as a repository for internal private package). Reason is some of the production machines are not allowed to go out to the internet.

When installed a package that itself has a "setup requirement" (in our concrete use-case it is the "cryptography" package, i.e. having dependencies for compiling sources), buildout would not pass the index URL nor "find links" on to the easy install calls. 

This PR fixes that albeit maybe in an naive fashion. I'd like to get some feedback on:

a) If this is anywhere near an acceptable approach. If not, perhaps someone can suggest a better approach?
b) How to write a tests for this. I tested locally by adding an entry for `pypi.python.org` pointing to `127.0.0.1` in my `/etc/hosts`. How would we mimic not being able to access anything but the index URL from the tests?
c) If the PR is against the correct branch 

Help and feedback is highly appreciated.