### PR TITLE
Support coverage for subprocess.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = zc.buildout
+parallel = true
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ python*/
 *.egg-info
 dist
 .tox
+.coverage
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ notifications:
 
 install:
     - ls -al pythons
+    - export COVERAGE_PROCESS_START=
     - deactivate
     - make build
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Change History
   considered outdated and lead to parts being reinstalled spuriously
   under Python 2.
 
+- Add support code for doctests to be able to easily measure code
+  coverage. See `issue 397 <https://github.com/buildout/buildout/issues/397>`_.
 
 2.9.3 (2017-03-30)
 ==================

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,12 +8,14 @@ zope.interface = 4.1.3
 zope.exceptions = 4.0.8
 zc.recipe.testrunner = 2.0.0
 zope.testing = 4.5.0
+coverage = 4.4.1
 
 [py]
 recipe = zc.recipe.egg
 eggs = zc.buildout[test]
        zc.recipe.egg
        zope.testing
+       coverage
 interpreter = py
 
 [test]
@@ -21,6 +23,10 @@ recipe = zc.recipe.testrunner
 eggs =
   zc.buildout[test]
   zc.recipe.egg
+initialization =
+  import os
+  if 'COVERAGE_PROCESS_START' not in os.environ: os.environ['COVERAGE_PROCESS_START'] = os.path.abspath('../../.coveragerc')
+  if os.getenv('COVERAGE_PROCESS_START'): import coverage; coverage.process_startup()
 
 # Tests that can be run wo a network
 [oltest]

--- a/src/zc/buildout/testing.txt
+++ b/src/zc/buildout/testing.txt
@@ -96,7 +96,7 @@ number of names to the test namespace:
     down at the end of the test.  The server URL is returned.
 
     You can cause the server to start and stop logging it's output
-    using: 
+    using:
 
        >>> get(server_url+'enable_server_logging')
 
@@ -119,6 +119,37 @@ number of names to the test namespace:
     and placing the result in the given destination
     directory.  If the setup argument is a directory, then the
     setup.py file in that directory is used.
+
+Code Coverage Measurement
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``buildoutSetUp`` prepares a new ``bin/buildout`` executable for
+doctests to run. Because this is will run in a subprocess, there are
+some extra steps needed to collect code coverage data for buildout and
+buildout recipes. This function does most of the heavy lifting for
+you, you only need to do a few things.
+
+First, you need to define a coverage configuration ('.coveragerc')
+which specifies that multiple different runs should be collected::
+
+    [run]
+    source = my.egg.name
+    parallel = true
+
+Second, when you invoke the test runner, you need to define the
+``COVERAGE_PROCESS_START`` environment variable to point to this
+configuration and invoke it with coverage::
+
+    COVERAGE_PROCESS_START=.coveragerc coverage run -m zope.testrunner --test-path=src
+
+Finally, after the tests have finished, you need to combine the
+resulting coverage data files and then you can produce reports::
+
+    coverage combine
+    coverage report
+
+.. caution:: You must be working in an environment (e.g., a virtual
+			 environment) that has coverage already installed.
 
 ``zc.buildout.testing.buildoutTearDown(test)``
 ----------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,13 @@ envlist =
 
 [testenv]
 commands =
+    pip install coverage
     # buildout's dev.py wants python to not have setuptools
     pip uninstall -y zc.buildout setuptools pip
     python dev.py
     {toxinidir}/bin/test -1 -v -c
+    coverage combine
+    coverage report
 # since we're removing setuptools we can't possibly reuse the virtualenv
 recreate = true
 # if the user has ccache installed, PATH may contain /usr/lib/ccache that has a


### PR DESCRIPTION
Fixes #397.

tox will produce the coverage reports by default.

Travis currently has the coverage disabled because it wants to work in a completely isolated python (can it be changed to invoke tox, maybe?).

Unfortunately because of #398 it's difficult to prove that it works. I have tested it with zopefoundation/zc.recipe.cmmi#2, though, and it does work there.