### PR TITLE
Update easy_install.py

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -209,7 +209,7 @@ def dist_needs_pkg_resources(dist):
         dist.has_metadata('namespace_packages.txt') and
         # This will need to change when `pkg_resources` gets its own
         # project:
-        'setuptools' not in {r.project_name for r in dist.requires()} and
+        'setuptools' not in (r.project_name for r in dist.requires()) and
         namespace_packages_need_pkg_resources(dist)
     )
 


### PR DESCRIPTION
line212: "{r.project_name for r in dist.requires()}" is an invalid syntax in Python 2.6, so (r.project_name for r in dist.requires()) would be better to make it compatible with Python 2.6