### PR TITLE
Use HTTPS for default PyPI index

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 2.9.5 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Use HTTPS for PyPI's index.  PyPI redirects HTTP to HTTPS by default
+  now so using HTTPS directly avoids the potential for that redirect
+  being modified in flight.
 
 
 2.9.4 (2017-06-20)

--- a/src/zc/buildout/buildout.txt
+++ b/src/zc/buildout/buildout.txt
@@ -3174,9 +3174,9 @@ using the `index` option::
 
   [buildout]
   ...
-  index = http://index.example.com/
+  index = https://index.example.com/
 
-This index, or the default of http://pypi.python.org/simple/ if no
+This index, or the default of https://pypi.python.org/simple/ if no
 index is specified, will always be searched for distributions unless
 running buildout with options that prevent searching for
 distributions. The latest version of the distribution that meets the

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -46,7 +46,7 @@ def realpath(path):
 
 default_index_url = os.environ.get(
     'buildout-testing-index-url',
-    'http://pypi.python.org/simple',
+    'https://pypi.python.org/simple',
     )
 
 logger = logging.getLogger('zc.buildout.easy_install')

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -46,7 +46,7 @@ index
    The URL of an index server, or almost any other valid URL. :)
 
    If not specified, the Python Package Index,
-   http://pypi.python.org/simple/, is used.  You can specify an
+   https://pypi.python.org/simple/, is used.  You can specify an
    alternate index with this option.  If you use the links option and
    if the links point to the needed distributions, then the index can
    be anything and will be largely ignored.  In the examples, here,
@@ -1077,7 +1077,7 @@ index
    The URL of an index server, or almost any other valid URL. :)
 
    If not specified, the Python Package Index,
-   http://pypi.python.org/simple/, is used.  You can specify an
+   https://pypi.python.org/simple/, is used.  You can specify an
    alternate index with this option.  If you use the links option and
    if the links point to the needed distributions, then the index can
    be anything and will be largely ignored.  In the examples, here,

--- a/src/zc/buildout/repeatable.txt
+++ b/src/zc/buildout/repeatable.txt
@@ -317,8 +317,8 @@ When everything is pinned, no output is generated:
     recipe v2
 
 The Python package index is case-insensitive. Both
-http://pypi.python.org/simple/Django/ and
-http://pypi.python.org/simple/dJaNgO/ work. And distributions aren't always
+https://pypi.python.org/simple/Django/ and
+https://pypi.python.org/simple/dJaNgO/ work. And distributions aren't always
 naming themselves consistently case-wise. So all version names are normalized
 and case differences won't impact the pinning:
 


### PR DESCRIPTION
PyPI redirects all requests from HTTP to HTTPS by default now so using HTTPS directly avoids the potential for that redirect being modified in flight, helping prevent MITM attacks.

Fixes #114.  The old comments over there aren't applicable any longer.