### PR TITLE
Update ez_setup source for 1.x bootstrap

### DIFF
--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -69,9 +69,8 @@ for k, v in sys.modules.items():
 
 is_jython = sys.platform.startswith('java')
 
-setuptools_source = 'http://peak.telecommunity.com/dist/ez_setup.py'
-distribute_source = 'http://python-distribute.org/distribute_setup.py'
-
+setuptools_source = 'https://bootstrap.pypa.io/ez_setup.py'
+distribute_source = 'https://bitbucket.org/pypa/setuptools/raw/f657df1f1ed46596d236376649c99a470662b4ba/distribute_setup.py'
 
 # parsing arguments
 def normalize_to_url(option, opt_str, value, parser):

--- a/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap.py
@@ -21,6 +21,8 @@ use the -c option to specify an alternate configuration file.
 import os, shutil, sys, tempfile, urllib, urllib2, subprocess
 from optparse import OptionParser
 
+__version__ = '1.x-2017-10-27'
+
 if sys.platform == 'win32':
     def quote(c):
         if ' ' in c:


### PR DESCRIPTION
The outdated one wants to download from http pypi, which fails since yesterday.
We now use the same ez_setup source as the `bootstrap.py` from master.
It is the same fix as on [Plone coredev 4.3](https://github.com/plone/buildout.coredev/commit/316da91ced540273bc161987b43423955ee5d8c7) which should fix the [error on Jenkins](http://jenkins.plone.org/job/pull-request-4.3/59/console):

```
Downloading http://pypi.python.org/packages/2.7/s/setuptools/setuptools-0.6c11-py2.7.egg
Traceback (most recent call last):
  File "bootstrap.py", line 170, in <module>
    ez['use_setuptools'](**setup_args)
  File "<string>", line 103, in use_setuptools
  File "<string>", line 97, in do_download
  File "<string>", line 158, in download_setuptools
  File "/usr/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 435, in open
    response = meth(req, response)
  File "/usr/lib/python2.7/urllib2.py", line 548, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python2.7/urllib2.py", line 473, in error
    return self._call_chain(*args)
  File "/usr/lib/python2.7/urllib2.py", line 407, in _call_chain
    result = func(*args)
  File "/usr/lib/python2.7/urllib2.py", line 556, in http_error_default
    raise HTTPError(req.get_full_url(), code, msg, hdrs, fp)
urllib2.HTTPError: HTTP Error 403: SSL is required
```

Is this the correct spot for such a change? I see a minor difference (in the distribute_source url) when comparing the file on this branch with http://downloads.buildout.org/1/bootstrap.py.

