### PR TITLE
Fixed: could not install eggs with case issues

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Change History
 2.9.6 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fixed: could not install eggs when sdist file name and package name had different
+  case.
 
 
 2.9.5 (2017-09-22)

--- a/src/zc/buildout/downloadcache.txt
+++ b/src/zc/buildout/downloadcache.txt
@@ -44,6 +44,7 @@ download:
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="index/">index/</a><br>
+    <a href="mixedcase-0.5.zip">mixedcase-0.5.zip</a><br>
     <a href="other-1.0-py2.4.egg">other-1.0-py2.4.egg</a><br>
     </body></html>
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1655,8 +1655,8 @@ def _get_matching_dist_in_location(dist, location):
     # good enough.
     env = pkg_resources.Environment([location])
     dists = [ d for project_name in env for d in env[project_name] ]
-    dist_infos = [ (d.project_name, d.version) for d in dists ]
-    if dist_infos == [(dist.project_name, dist.version)]:
+    dist_infos = [ (d.project_name.lower(), d.version) for d in dists ]
+    if dist_infos == [(dist.project_name.lower(), dist.version)]:
         return dists.pop()
 
 def _move_to_eggs_dir_and_compile(dist, dest):

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -104,6 +104,7 @@ We have a link server that has a number of eggs:
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="index/">index/</a><br>
+    <a href="mixedcase-0.5.zip">mixedcase-0.5.zip</a><br>
     <a href="other-1.0-py2.4.egg">other-1.0-py2.4.egg</a><br>
     </body></html>
 
@@ -183,6 +184,7 @@ Let's put the setting back to the default.
     >>> zc.buildout.easy_install.prefer_final(True)
     False
 
+
 We can supply additional distributions.  We can also supply
 specifications for distributions that would normally be found via
 dependencies.  We might do this to specify a specific version.
@@ -206,6 +208,38 @@ dependencies.  We might do this to specify a specific version.
     d  demoneeded-1.2rc1-py2.4.egg
     d  other-1.0-py2.4.egg
 
+    >>> rmdir(dest)
+
+Case issues
+-----------
+
+Let's install an egg with case naming issues.
+Specifically, the sdist file is lower case while the name of the package is uppercase.
+
+Let's enable server logging to check that the lower case file is downloaded.
+
+    >>> _ = get(link_server + 'enable_server_logging')
+    GET 200 /enable_server_logging
+    >>> ws = zc.buildout.easy_install.install(
+    ...     ['MIXEDCASE'], dest,
+    ...     links=[link_server], index=link_server+'index/')
+    GET 404 /index/MIXEDCASE/
+    GET 200 /mixedcase-0.5.zip
+    GET 200 /demoneeded-1.1.zip
+
+Let's check that the uppercase dist is installed.
+
+    >>> for dist in ws:
+    ...     print_(dist)
+    MIXEDCASE 0.5
+    demoneeded 1.1
+    >>> ls(dest)
+    d  MIXEDCASE-0.5-pyN.N.egg
+    d  demoneeded-1.1-py2.4.egg
+
+And cleanup.
+
+    >>> _ = get(link_server + 'disable_server_logging')
     >>> rmdir(dest)
 
 Specifying version information independent of requirements
@@ -1170,6 +1204,7 @@ Let's update our link server with a new version of extdemo:
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="extdemo-1.5.zip">extdemo-1.5.zip</a><br>
     <a href="index/">index/</a><br>
+    <a href="mixedcase-0.5.zip">mixedcase-0.5.zip</a><br>
     <a href="other-1.0-py2.4.egg">other-1.0-py2.4.egg</a><br>
     </body></html>
 

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3265,6 +3265,25 @@ def create_sample_eggs(test, executable=sys.executable):
                 )
             zc.buildout.testing.bdist_egg(tmp, dest)
 
+        write(tmp, 'mixedcase.py', 'def f():\n  pass')
+        write(
+            tmp, 'setup.py',
+            "from setuptools import setup\n"
+            "setup(name='MIXEDCASE', py_modules=['mixedcase'],"
+            " author='bob', url='bob', author_email='bob',"
+            " install_requires = 'demoneeded',"
+            " zip_safe=True, version='0.5')\n"
+            )
+        zc.buildout.testing.sdist(tmp, dest)
+        # rename file to lower case 
+        # to test issues between file and package name
+        curdir = os.getcwd()
+        os.chdir(dest)
+        for file in os.listdir(dest):
+            if "MIXEDCASE" in file:
+                os.rename(file, file.lower())
+        os.chdir(curdir)
+
         write(tmp, 'eggrecipebigdemo.py', 'import eggrecipedemo')
         write(
             tmp, 'setup.py',

--- a/zc.recipe.egg_/src/zc/recipe/egg/README.rst
+++ b/zc.recipe.egg_/src/zc/recipe/egg/README.rst
@@ -38,6 +38,7 @@ We have a link server that has a number of distributions:
     <a href="du_zipped-1.0-pyN.N.egg">du_zipped-1.0-pyN.N.egg</a><br>
     <a href="extdemo-1.4.zip">extdemo-1.4.zip</a><br>
     <a href="index/">index/</a><br>
+    <a href="mixedcase-0.5.zip">mixedcase-0.5.zip</a><br>
     <a href="other-1.0-py2.3.egg">other-1.0-py2.3.egg</a><br>
     </body></html>
 


### PR DESCRIPTION
For instance when sdist file name and package name had different case.

Integrates patch proposed at https://github.com/buildout/buildout.wheel/issues/10#issuecomment-297661933

Should fix #385 #395 