### PR TITLE
Install wheels via setuptools, fixes #425

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change History
 ==================
 
 - Setuptools 38.2.0 started supporting wheels. Through setuptools, buildout
-  now also supports wheels!
+  now also supports wheels! You need at least version 38.2.3 to get proper
+  namespace support.
 
   This setuptools change interfered with buildout's recent support for
   `buildout.wheel <https://github.com/buildout/buildout.wheel>`_, resulting in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,15 @@ Change History
 2.9.6 (unreleased)
 ==================
 
-- Setuptools 38.2.0 started supporting wheels. This interfered with buildout's
-  recent support for `buildout.wheel
-  <https://github.com/buildout/buildout.wheel>`_. Setuptools is the default
-  now, but you can still use the buildout.wheel if you want.
+- Setuptools 38.2.0 started supporting wheels. Through setuptools, buildout
+  now also supports wheels!
+
+  This setuptools change interfered with buildout's recent support for
+  `buildout.wheel <https://github.com/buildout/buildout.wheel>`_, resulting in
+  a sudden "Wheels are not supported" error message (see `issue 435
+  <https://github.com/buildout/buildout/issues/425>`_). Fixed by making
+  setuptools the default, though you can still use the buildout.wheel if you
+  want.
 
 
 2.9.5 (2017-09-22)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,10 @@ Change History
 2.9.6 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Setuptools 38.2.0 started supporting wheels. This interfered with buildout's
+  recent support for `buildout.wheel
+  <https://github.com/buildout/buildout.wheel>`_. Setuptools is the default
+  now, but you can still use the buildout.wheel if you want.
 
 
 2.9.5 (2017-09-22)

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1624,7 +1624,7 @@ def unpack_egg(location, dest):
 
 WHEEL_WARNING = """
 *.whl file detected (%s), you'll need setuptools > 38.2.3 for that
-or an extension like buildout.wheel
+or an extension like buildout.wheel > 0.2.0.
 """
 
 
@@ -1633,7 +1633,7 @@ def unpack_wheel(location, dest):
         wheel = Wheel(location)
         wheel.install_as_egg(os.path.join(dest, wheel.egg_name()))
     else:
-        logger.warning(WHEEL_WARNING, location)
+        logger.error(WHEEL_WARNING, location)
 
 
 UNPACKERS = {

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1637,7 +1637,7 @@ def unpack_wheel(location, dest):
         wheel = Wheel(location)
         wheel.install_as_egg(os.path.join(dest, wheel.egg_name()))
     else:
-        logger.error(WHEEL_WARNING, location)
+        raise zc.buildout.UserError(WHEEL_WARNING % location)
 
 
 UNPACKERS = {

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1626,7 +1626,7 @@ def unpack_egg(location, dest):
 
 
 WHEEL_WARNING = """
-*.whl file detected (%s), you'll need setuptools > 38.2.0 for that
+*.whl file detected (%s), you'll need setuptools > 38.2.3 for that
 or an extension like buildout.wheel
 """
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1637,11 +1637,11 @@ def unpack_wheel(location, dest):
     [egg] = glob.glob(os.path.join(tmp_dest, '*.egg'))
     unpack_egg(egg, dest)
     shutil.rmtree(tmp_dest)
-    
+
 
 UNPACKERS = {
     '.egg': unpack_egg,
-    '.whl': unpack_wheel,
+    '.whl': unpack_egg,  # Since 38.2, setuptools handles wheels, too.
 }
 
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -89,9 +89,6 @@ setuptools_path = buildout_and_setuptools_path
 FILE_SCHEME = re.compile('file://', re.I).match
 DUNDER_FILE_PATTERN = re.compile(r"__file__ = '(?P<filename>.+)'$")
 
-def wheel_to_egg(dist, dest):
-    raise zc.buildout.UserError("Wheels are not supported")
-
 class _Monkey(object):
     def __init__(self, module, **kw):
         mdict = self._mdict = module.__dict__

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1623,7 +1623,7 @@ def unpack_egg(location, dest):
 
 
 WHEEL_WARNING = """
-*.whl file detected (%s), you'll need setuptools > 38.2.3 for that
+*.whl file detected (%s), you'll need setuptools >= 38.2.3 for that
 or an extension like buildout.wheel > 0.2.0.
 """
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -38,8 +38,12 @@ import zc.buildout
 import warnings
 
 try:
-    from setuptools.wheel import Wheel
-    SETUPTOOLS_SUPPORTS_WHEELS = True
+    from setuptools.wheel import Wheel  # This is the important import
+    from setuptools import __version__ as setuptools_version
+    # Now we need to check if we have at least 38.2.3 for namespace support.
+    SETUPTOOLS_SUPPORTS_WHEELS = (
+        pkg_resources.SetuptoolsVersion(setuptools_version) >=
+        pkg_resources.SetuptoolsVersion('38.2.3'))
 except ImportError:
     SETUPTOOLS_SUPPORTS_WHEELS = False
 

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3144,53 +3144,6 @@ def test_buildout_doesnt_keep_adding_itself_to_versions():
 if sys.platform == 'win32':
     del buildout_honors_umask # umask on dohs is academic
 
-class UnitTests(unittest.TestCase):
-
-    @property
-    def globs(self):
-        return self.__dict__
-
-    def setUp(self):
-        easy_install_SetUp(self)
-        import setuptools.package_index
-        setuptools.package_index.EXTENSIONS.append('.whl')
-        import zc.buildout.easy_install
-        self.orig_wheel_to_egg = zc.buildout.easy_install.wheel_to_egg
-
-    def tearDown(self):
-        import zc.buildout.easy_install
-        zc.buildout.testing.buildoutTearDown(self)
-        import setuptools.package_index
-        setuptools.package_index.EXTENSIONS.remove('.whl')
-        zc.buildout.easy_install.wheel_to_egg = self.orig_wheel_to_egg
-
-    def test_wheel_to_egg(self):
-        [egg_name] = [n for n in os.listdir(self.sample_eggs)
-                  if n.startswith('demo-0.3-')]
-        path = os.path.join(self.sample_eggs, egg_name)
-        os.rename(path, os.path.join(self.sample_eggs,
-                                     'demo-0.3-py2.py3-none-any.whl'))
-
-        import zc.buildout.easy_install
-        installer = zc.buildout.easy_install.Installer(
-            os.path.join(self.sample_buildout, 'eggs'),
-            index = self.sample_eggs)
-
-        # Can't install because the original hook is in place:
-        with self.assertRaises(zc.buildout.UserError):
-            installer.install(['demo'])
-
-        def wheel_to_egg(dist, dest):
-            newloc = os.path.join(dest, egg_name)
-            shutil.copy(dist.location, newloc)
-            return pkg_resources.Distribution.from_filename(newloc)
-        zc.buildout.easy_install.wheel_to_egg = wheel_to_egg
-        egg_dir = os.path.join(self.sample_buildout, 'eggs')
-        self.assertFalse(egg_name in os.listdir(egg_dir))
-        installer.install(['demo'])
-        self.assertTrue(egg_name in os.listdir(egg_dir))
-
-
 ######################################################################
 
 def create_sample_eggs(test, executable=sys.executable):

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3704,7 +3704,6 @@ def test_suite():
                ])
             ),
         doctest.DocFileSuite('testing_bugfix.txt'),
-        unittest.makeSuite(UnitTests),
     ]
 
     docdir = os.path.join(ancestor(__file__, 4), 'doc')

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3168,7 +3168,8 @@ class UnitTests(unittest.TestCase):
         [egg_name] = [n for n in os.listdir(self.sample_eggs)
                   if n.startswith('demo-0.3-')]
         path = os.path.join(self.sample_eggs, egg_name)
-        os.rename(path, os.path.join(self.sample_eggs, 'demo-0.3.whl'))
+        os.rename(path, os.path.join(self.sample_eggs,
+                                     'demo-0.3-py2.py3-none-any.whl'))
 
         import zc.buildout.easy_install
         installer = zc.buildout.easy_install.Installer(


### PR DESCRIPTION
Default to setuptools' wheel support instead of failing

Setuptools 38.2.0 suddenly started supporting and downloading wheels.
.whl files would end up in the non-functioning and deprecated unpack_wheel().
The new default ('just use setuptools') works fine.

- If you use an older setuptools, setuptools won't download wheels and the new
  code won't be used.

- If you use buildout.wheel, you'll overwrite the unpacker anyway.

Fixes #425