### PR TITLE
Fix race condition with working set not reflecting reality during integrity check.

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -568,6 +568,9 @@ class Installer:
                         "Couldn't download distribution %s." % avail)
 
                 dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
+                for _d in dists:
+                    if _d not in ws:
+                        ws.add(_d, replace=True)
 
             finally:
                 if tmp != self._download_cache:
@@ -575,10 +578,14 @@ class Installer:
 
             self._env_rescan_dest()
             dist = self._env.best_match(requirement, ws)
+
             logger.info("Got %s.", dist)
 
         else:
             dists = [dist]
+            if dist not in ws:
+                ws.add(dist)
+
 
         if not self._install_from_cache and self._use_dependency_links:
             self._add_dependency_links_from_dists(dists)
@@ -635,8 +642,7 @@ class Installer:
                 pkg_resources.Requirement.parse('setuptools')
                 )
             if ws.find(requirement) is None:
-                for dist in self._get_dist(requirement, ws):
-                    ws.add(dist)
+                self._get_dist(requirement, ws)
 
     def _constrain(self, requirement):
         """Return requirement with optional [versions] constraint added."""
@@ -670,7 +676,6 @@ class Installer:
 
         for requirement in requirements:
             for dist in self._get_dist(requirement, ws):
-                ws.add(dist)
                 self._maybe_add_setuptools(ws, dist)
 
         # OK, we have the requested distributions and they're in the working
@@ -719,7 +724,6 @@ class Installer:
                     logger.debug('Adding required %r', str(req))
                 self._log_requirement(ws, req)
                 for dist in self._get_dist(req, ws):
-                    ws.add(dist)
                     self._maybe_add_setuptools(ws, dist)
             if dist not in req:
                 # Oops, the "best" so far conflicts with a dependency.

--- a/src/zc/buildout/easy_install.txt
+++ b/src/zc/buildout/easy_install.txt
@@ -125,8 +125,8 @@ The working set contains the distributions we retrieved.
 
     >>> for dist in ws:
     ...     print_(dist)
-    demo 0.2
     demoneeded 1.1
+    demo 0.2
 
 We got demoneeded because it was a dependency of demo.
 
@@ -169,8 +169,8 @@ The old setting is returned.
     ...     ['demo'], dest, links=[link_server], index=link_server+'index/')
     >>> for dist in ws:
     ...     print_(dist)
-    demo 0.4rc1
     demoneeded 1.2rc1
+    demo 0.4rc1
 
     >>> ls(dest)
     d  demo-0.2-py2.4.egg
@@ -195,9 +195,9 @@ dependencies.  We might do this to specify a specific version.
 
     >>> for dist in ws:
     ...     print_(dist)
-    demo 0.3
-    other 1.0
     demoneeded 1.0
+    other 1.0
+    demo 0.3
 
     >>> ls(dest)
     d  demo-0.2-py2.4.egg
@@ -231,8 +231,8 @@ Let's check that the uppercase dist is installed.
 
     >>> for dist in ws:
     ...     print_(dist)
-    MIXEDCASE 0.5
     demoneeded 1.1
+    MIXEDCASE 0.5
     >>> ls(dest)
     d  MIXEDCASE-0.5-pyN.N.egg
     d  demoneeded-1.1-py2.4.egg
@@ -256,7 +256,7 @@ then the versions numbers will be used.
     ...     ['demo'], dest, links=[link_server], index=link_server+'index/',
     ...     versions = dict(demo='0.2', demoneeded='1.0'))
     >>> [d.version for d in ws]
-    ['0.2', '1.0']
+    ['1.0', '0.2']
 
 In this example, we specified a version for demoneeded, even though we
 didn't define a requirement for it.  The versions specified apply to
@@ -890,8 +890,8 @@ to pass a common base directory of the scripts and eggs:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      join(base, 'eggs/demo-0.3-pyN.N.egg'),
       join(base, 'eggs/demoneeded-1.1-pyN.N.egg'),
+      join(base, 'eggs/demo-0.3-pyN.N.egg'),
       '/ba',
       join(base, 'bar'),
       base,
@@ -924,12 +924,13 @@ We specified an interpreter and its paths are adjusted too:
     import sys
     <BLANKLINE>
     sys.path[0:0] = [
-      join(base, 'eggs/demo-0.3-pyN.N.egg'),
       join(base, 'eggs/demoneeded-1.1-pyN.N.egg'),
+      join(base, 'eggs/demo-0.3-pyN.N.egg'),
       '/ba',
       join(base, 'bar'),
       base,
       ]
+    <BLANKLINE>
     <BLANKLINE>
     _interactive = True
     if len(sys.argv) > 1:

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -2018,8 +2018,8 @@ def bug_61890_file_urls_dont_seem_to_work_in_find_dash_links():
 
     >>> for dist in ws:
     ...     print_(dist)
-    demo 0.2
     demoneeded 1.1
+    demo 0.2
 
     >>> ls(dest)
     d  demo-0.2-py2.4.egg
@@ -3229,7 +3229,7 @@ def create_sample_eggs(test, executable=sys.executable):
             " zip_safe=True, version='0.5')\n"
             )
         zc.buildout.testing.sdist(tmp, dest)
-        # rename file to lower case 
+        # rename file to lower case
         # to test issues between file and package name
         curdir = os.getcwd()
         os.chdir(dest)

--- a/src/zc/buildout/update.txt
+++ b/src/zc/buildout/update.txt
@@ -87,8 +87,8 @@ Our buildout script has been updated to use the new eggs:
     <BLANKLINE>
     import sys
     sys.path[0:0] = [
-      '/sample-buildout/eggs/zc.buildout-99.99-py2.4.egg',
       '/sample-buildout/eggs/setuptools-99.99-py2.4.egg',
+      '/sample-buildout/eggs/zc.buildout-99.99-py2.4.egg',
       ]
     <BLANKLINE>
     import zc.buildout.buildout

--- a/zc.recipe.egg_/src/zc/recipe/egg/api.rst
+++ b/zc.recipe.egg_/src/zc/recipe/egg/api.rst
@@ -89,9 +89,9 @@ of extra requirements to be included in the working set.
     Egg requirements:
     demo<0.3
     Working set:
-    demo 0.2
-    other 1.0
     demoneeded 1.1
+    other 1.0
+    demo 0.2
     extra paths: []
 
 We can see that the options were augmented with additional data


### PR DESCRIPTION
In easy_install.Installer._get_dist, a package is retrieved and installed in the eggs folder (eg. ~/.buildout/eggs).

Previously, the program would re-scan the environment for changes, check that the newly downloaded package was accessible and return a list of packages (allowing for dependencies) which were installed.  These packages would then be added to the working set.

The problem was that the accessibility check was done against a working set that did not yet reflect the newly downloaded packages.  This was not generally a problem, except where a conflicting package was already installed (for example in sdist).  In such a case, buildout would fail, reporting a version conflict, but running buildout directly afterward would succeed because the environment and working set would contain the packages installed in the eggs folder, and there would be no conflict.

This patch moves the "ws.add(dist)" calls from where they previously were, to inside the _get_dist() method, and adds the "replace=True" flag which effectively replaces any conflicting working set packages with the newly downloaded ones.  Now when we do:

            self._env_rescan_dest()
            dist = self._env.best_match(requirement, ws)

we are testing against a working set that reflects the true file system state, and buildout runs consistently.

Fixes #423