### PR TITLE
Correctly detect upgrade with extension that depends on setuptools

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 2.11.1 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Made upgrade check more robust. When using extensions, the improvement
+  introduced in 2.11 could prevent buildout from restarting itself when it
+  upgraded setuptools.
 
 
 2.11.0 (2018-01-21)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1083,10 +1083,13 @@ class Buildout(DictMixin):
             )
 
         upgraded = []
+        # The setuptools/zc.buildout locations at the time we started was
+        # recorded in easy_install.py. We use that here to check if we've been
+        # upgraded.
+        start_locations = zc.buildout.easy_install.buildout_and_setuptools_path
         for project in 'zc.buildout', 'setuptools':
             req = pkg_resources.Requirement.parse(project)
-            project_location = pkg_resources.working_set.find(req).location
-            if ws.find(req).location != project_location:
+            if ws.find(req).location not in start_locations:
                 upgraded.append(ws.find(req))
 
         if not upgraded:


### PR DESCRIPTION
Use case: buildout that uses mr.developer. When you bootstrap it with ye olde bootstrap.py, it starts up with setuptools 33.1.1. 

When installing the mr.developer extension, it upgrades setuptools to 38.5.2 (as we've pinned that version). With the new buildout 2.11 functionality, installed packages are immediately added to the working set.

After installing the extension, the `maybe_upgrade()` function it called. This checked the working set if it was up to date with the currently installed packages. With buildout 2.11, this was always the case.

I've changed the check to look at the buildout/setuptools install locations that were detected when first loading the `easy_install.py` module.