### PR TITLE
Fix for #442 issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change History
 2.11.2 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Fix #442 issue. [enkidulan]
 
 
 2.11.1 (2018-03-01)

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -42,8 +42,8 @@ try:
     from setuptools import __version__ as setuptools_version
     # Now we need to check if we have at least 38.2.3 for namespace support.
     SETUPTOOLS_SUPPORTS_WHEELS = (
-        pkg_resources.SetuptoolsVersion(setuptools_version) >=
-        pkg_resources.SetuptoolsVersion('38.2.3'))
+        pkg_resources.parse_version(setuptools_version) >=
+        pkg_resources.parse_version('38.2.3'))
 except ImportError:
     SETUPTOOLS_SUPPORTS_WHEELS = False
 


### PR DESCRIPTION
`pkg_resources.SetuptoolsVersion` got deprecated in `setuptools` `v39.0.0`.
Moved on using stable and recommended `pkg_resources.parse_version`
function that does the same. For more details on the topic
see http://setuptools.readthedocs.io/en/latest/history.html#v39-0-0.