### PR TITLE
fix #295: temporary egg files are created as read only and can't be deleted with shutil on Windows.

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -35,6 +35,7 @@ import subprocess
 import sys
 import tempfile
 import zc.buildout
+import zc.buildout.rmtree
 import warnings
 
 try:
@@ -453,7 +454,7 @@ class Installer:
             return result
 
         finally:
-            shutil.rmtree(tmp)
+            zc.buildout.rmtree.rmtree(tmp)
 
     def _obtain(self, requirement, source=None):
         # initialize out index for this project:
@@ -574,7 +575,7 @@ class Installer:
 
             finally:
                 if tmp != self._download_cache:
-                    shutil.rmtree(tmp)
+                    zc.buildout.rmtree.rmtree(tmp)
 
             self._env_rescan_dest()
             dist = self._env.best_match(requirement, ws)
@@ -804,11 +805,11 @@ class Installer:
 
                 return [dist.location for dist in dists]
             finally:
-                shutil.rmtree(build_tmp)
+                zc.buildout.rmtree.rmtree(build_tmp)
 
         finally:
             if tmp != self._download_cache:
-                shutil.rmtree(tmp)
+                zc.buildout.rmtree.rmtree(tmp)
 
     def _fix_file_links(self, links):
         for link in links:
@@ -945,7 +946,7 @@ def build(spec, dest, build_ext,
 def _rm(*paths):
     for path in paths:
         if os.path.isdir(path):
-            shutil.rmtree(path)
+            zc.buildout.rmtree.rmtree(path)
         elif os.path.exists(path):
             os.remove(path)
 
@@ -1051,7 +1052,7 @@ def develop(setup, dest,
             )).encode())
 
         tmp3 = tempfile.mkdtemp('build', dir=dest)
-        undo.append(lambda : shutil.rmtree(tmp3))
+        undo.append(lambda : zc.buildout.rmtree.rmtree(tmp3))
 
         args = [executable,  tsetup, '-q', 'develop', '-mN', '-d', tmp3]
 
@@ -1738,5 +1739,5 @@ def _move_to_eggs_dir_and_compile(dist, dest):
             assert newdist is not None  # newloc above is missing our dist?!
     finally:
         # Remember that temporary directories must be removed
-        shutil.rmtree(tmp_dest)
+        zc.buildout.rmtree.rmtree(tmp_dest)
     return newdist

--- a/src/zc/buildout/rmtree.py
+++ b/src/zc/buildout/rmtree.py
@@ -57,13 +57,11 @@ def rmtree (path):
     """
     def retry_writeable (func, path, exc):
         os.chmod (path, 384) # 0600
-        tries = 10
-        while tries:
+        for i in range(10):
             try:
                 func (path)
                 break
             except OSError:
-                tries -= 1
                 time.sleep(0.1)
         else:
             # tried 10 times without success, thus


### PR DESCRIPTION
1. Simply also re-use zc.buildout.rmtree in easy_install.py.
2. Additionally try even harder (as mentioned in zc.buildout's rmtree) removing folders, for instance, when getting "WindowsError: [Error 32]", which only happens "sometimes" and nobody knows why (e.g. antivirus is deactivated).

Traceback (most recent call last):
  File "C:\platform\15.3.auto\lib\site-packages\zc.buildout-2.11.0-py2.7.egg\zc\buildout\buildout.py", line 2123, in main
    getattr(buildout, command)(args)
  File "C:\platform\15.3.auto\lib\site-packages\zc.buildout-2.11.0-py2.7.egg\zc\buildout\buildout.py", line 796, in install
    installed_files = self[part]._call(recipe.install)
  File "C:\platform\15.3.auto\lib\site-packages\zc.buildout-2.11.0-py2.7.egg\zc\buildout\buildout.py", line 1553, in _call
    return f()
  File "c:\bb\builders\cscdb.product_trunk_win32\build\eggs\cs.recipes-15.2.4-py2.7.egg\cs\recipes\instance.py", line 256, in install
    installed = Scripts.install(self)
  File "c:\bb\builders\cscdb.product_trunk_win32\build\eggs\zc.recipe.egg-2.0.5-py2.7.egg\zc\recipe\egg\egg.py", line 221, in install
    reqs, ws = self.working_set()
  File "c:\bb\builders\cscdb.product_trunk_win32\build\eggs\zc.recipe.egg-2.0.5-py2.7.egg\zc\recipe\egg\egg.py", line 84, in working_set
    allow_hosts=self.allow_hosts,
  File "c:\bb\builders\cscdb.product_trunk_win32\build\eggs\zc.recipe.egg-2.0.5-py2.7.egg\zc\recipe\egg\egg.py", line 162, in _working_set
    allow_hosts=allow_hosts)
  File "C:\platform\15.3.auto\lib\site-packages\zc.buildout-2.11.0-py2.7.egg\zc\buildout\easy_install.py", line 924, in install
    return installer.install(specs, working_set)
  File "C:\platform\15.3.auto\lib\site-packages\zc.buildout-2.11.0-py2.7.egg\zc\buildout\easy_install.py", line 678, in install
    for dist in self._get_dist(requirement, ws):
  File "C:\platform\15.3.auto\lib\site-packages\zc.buildout-2.11.0-py2.7.egg\zc\buildout\easy_install.py", line 577, in _get_dist
    shutil.rmtree(tmp)
  File "C:\platform\15.3.auto\lib\shutil.py", line 266, in rmtree
    onerror(os.remove, fullname, sys.exc_info())
  File "C:\platform\15.3.auto\lib\shutil.py", line 264, in rmtree
    os.remove(fullname)
WindowsError: [Error 32] The process cannot access the file because it is being used by another process: 'c:\\tmp\\tmp3b2xjbget_dist\\cs.threed-15.5.1.2-py2.7.egg'