### PR TITLE
Fix most Deprecation and Resource warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ clean:
 	rm -rf $(BUILD_DIRS) $(PYTHON_BUILD_DIR)
 
 test:
-	$(HERE)/bin/test -1 -vvv
+	$(HERE)/bin/test -1 -vvv -c

--- a/doc/topics/bootstrapping.rst
+++ b/doc/topics/bootstrapping.rst
@@ -97,6 +97,8 @@ And then run it:
    >>> eqs(os.listdir("."), 'bootstrap-buildout.py',
    ...     'buildout.cfg', 'eggs', 'bin', 'develop-eggs', 'parts')
    >>> os.chdir('..')
+   >>> p.stdout.close()
+   >>> p.stderr.close()
 
 It will download the software needed to run Buildout and install it in
 the current directory.
@@ -167,6 +169,8 @@ This can be used with the bootstrapping script as well:
    ...     print(p.stderr.read())
    >>> eqs(os.listdir("."), 'bootstrap-buildout.py',
    ...     'buildout.cfg', 'eggs', 'bin', 'develop-eggs', 'parts')
+   >>> p.stdout.close()
+   >>> p.stderr.close()
 
 This creates an empty Buildout configuration:
 
@@ -220,4 +224,3 @@ command above would generate a buildout configuration file:
 
 This can provide an easy way to experiment with a package without
 adding it to your Python environment or creating a virtualenv.
-

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ import os
 from setuptools import setup
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 long_description= read('README.rst') + '\n' + read('CHANGES.rst')
 

--- a/src/zc/buildout/bootstrap.txt
+++ b/src/zc/buildout/bootstrap.txt
@@ -19,7 +19,9 @@ Make sure the bootstrap script actually works::
     ... [buildout]
     ... parts =
     ... ''')
-    >>> write('bootstrap.py', open(bootstrap_py).read())
+    >>> with open(bootstrap_py) as f:
+    ...     bootstrap_py_contents = f.read()
+    >>> write('bootstrap.py', bootstrap_py_contents)
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable)+' '+
     ...     'bootstrap.py')); print_('X') # doctest: +ELLIPSIS
@@ -52,7 +54,7 @@ By default it gets the latest version::
     >>> buildout_script = join(sample_buildout, 'bin', 'buildout')
     >>> if sys.platform.startswith('win'):
     ...     buildout_script += '-script.py'
-    >>> print_(open(buildout_script).read()) # doctest: +ELLIPSIS
+    >>> with open(buildout_script) as f: print_(f.read()) # doctest: +ELLIPSIS
     #...
     sys.path[0:0] = [
       '/sample/eggs/zc.buildout-22.0.0...egg',
@@ -83,7 +85,7 @@ Now let's try with ``2.0.0``, which happens to exist::
 
 Let's make sure the generated ``buildout`` script uses it::
 
-    >>> print_(open(buildout_script).read()) # doctest: +ELLIPSIS
+    >>> with open(buildout_script) as f: print_(f.read()) # doctest: +ELLIPSIS
     #...
     sys.path[0:0] = [
       '/sample/eggs/zc.buildout-2.0.0...egg',
@@ -103,7 +105,7 @@ Now let's try with ``31.0.0``, which happens to exist::
 
 Let's make sure the generated ``buildout`` script uses it::
 
-    >>> print_(open(buildout_script).read()) # doctest: +ELLIPSIS
+    >>> with open(buildout_script) as f: print_(f.read()) # doctest: +ELLIPSIS
     #...
     sys.path[0:0] = [
       '/sample/eggs/zc.buildout-...egg',
@@ -121,7 +123,7 @@ which happens to exist::
 
 Let's make sure the generated ``buildout`` script uses it::
 
-    >>> print_(open(buildout_script).read()) # doctest: +ELLIPSIS
+    >>> with open(buildout_script) as f: print_(f.read()) # doctest: +ELLIPSIS
     #...
     sys.path[0:0] = [
       '/sample/eggs/zc.buildout-2.0.0...egg',
@@ -153,7 +155,7 @@ specify the setuptools version, and to reuse the setuptools zipfile::
     >>> os.path.exists('setuptools-32.1.0.zip')
     True
 
-    >>> print_(open(buildout_script).read()) # doctest: +ELLIPSIS
+    >>> with open(buildout_script) as f: print_(f.read()) # doctest: +ELLIPSIS
     #...
     sys.path[0:0] = [
       '/sample/eggs/zc.buildout-2.0.0...egg',

--- a/src/zc/buildout/bootstrap_cl_settings.test
+++ b/src/zc/buildout/bootstrap_cl_settings.test
@@ -20,7 +20,8 @@ Some people pass buildout settings to bootstrap.
     ... [buildout]
     ... parts =
     ... ''')
-    >>> write('bootstrap.py', open(bootstrap_py).read())
+    >>> with open(bootstrap_py) as f: bootstrap_py_contents = f.read()
+    >>> write('bootstrap.py', bootstrap_py_contents)
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable) +
     ...     ' bootstrap.py buildout:directory=' + top +
@@ -43,7 +44,8 @@ They might do it with init, but no worries:
     >>> os.chdir(top)
     >>> mkdir(top, 'buildout')
     >>> os.chdir(top)
-    >>> write('bootstrap.py', open(bootstrap_py).read())
+    >>> with open(bootstrap_py) as f: bootstrap_py_contents = f.read()
+    >>> write('bootstrap.py', bootstrap_py_contents)
     >>> print_('X'); print_(system(
     ...     zc.buildout.easy_install._safe_arg(sys.executable) +
     ...     ' bootstrap.py buildout:directory=' + top +

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -892,8 +892,8 @@ class Buildout(DictMixin):
                     setup = self._buildout_path(setup)
                     files = glob.glob(setup)
                     if not files:
-                        self._logger.warn("Couldn't develop %r (not found)",
-                                          setup)
+                        self._logger.warning("Couldn't develop %r (not found)",
+                                             setup)
                     else:
                         files.sort()
                     for setup in files:
@@ -1107,8 +1107,8 @@ class Buildout(DictMixin):
         if (realpath(os.path.abspath(sys.argv[0])) != should_run):
             self._logger.debug("Running %r.", realpath(sys.argv[0]))
             self._logger.debug("Local buildout is %r.", should_run)
-            self._logger.warn("Not upgrading because not running a local "
-                              "buildout command.")
+            self._logger.warning("Not upgrading because not running a local "
+                                 "buildout command.")
             return
 
         self._logger.info("Upgraded:\n  %s;\nrestarting.",
@@ -1463,7 +1463,7 @@ class Options(DictMixin):
 
     _template_split = re.compile('([$]{[^}]*})').split
     _simple = re.compile('[-a-zA-Z0-9 ._]+$').match
-    _valid = re.compile('\${[-a-zA-Z0-9 ._]*:[-a-zA-Z0-9 ._]+}$').match
+    _valid = re.compile(r'\${[-a-zA-Z0-9 ._]*:[-a-zA-Z0-9 ._]+}$').match
     def _sub(self, template, seen):
         value = self._template_split(template)
         subs = []
@@ -1562,7 +1562,7 @@ class Options(DictMixin):
                     elif os.path.isfile(p):
                         os.remove(p)
                     else:
-                        self.buildout._logger.warn("Couldn't clean up %r.", p)
+                        self.buildout._logger.warning("Couldn't clean up %r.", p)
                 raise
         finally:
             self._created = None
@@ -1920,9 +1920,9 @@ def _check_for_unused_options_in_section(buildout, section):
     unused = [option for option in sorted(options._raw)
               if option not in options._data]
     if unused:
-        buildout._logger.warn("Unused options for %s: %s."
-                              % (section, ' '.join(map(repr, unused)))
-                              )
+        buildout._logger.warning("Unused options for %s: %s."
+                                 % (section, ' '.join(map(repr, unused)))
+        )
 
 _usage = """\
 Usage: buildout [options] [assignments] [command [command arguments]]

--- a/src/zc/buildout/buildout.txt
+++ b/src/zc/buildout/buildout.txt
@@ -3347,3 +3347,7 @@ We see that our extension is loaded and executed::
     ext ['buildout', 'versions']
     Develop: '/sample-bootstrapped/demo'
     unload ['buildout', 'versions']
+
+..
+
+    >>> stop_server(server_url)

--- a/src/zc/buildout/configparser.py
+++ b/src/zc/buildout/configparser.py
@@ -178,7 +178,7 @@ def parse(fp, fpname, exp_globals=dict):
                     tail = tail.replace(';', '#') if tail else ''
                     # un-escape literal # and ; . Do not use a
                     # string-escape decode
-                    expr = expression.replace(r'\x23','#').replace(r'x3b', ';')
+                    expr = expression.replace(r'\x23','#').replace(r'\x3b', ';')
                     # rebuild a valid Python expression wrapped in a list
                     expr = head + expr + tail
                     # lazily populate context only expression

--- a/src/zc/buildout/configparser.test
+++ b/src/zc/buildout/configparser.test
@@ -33,7 +33,7 @@ First, an example that illustrates a well-formed configuration::
   b    += 1
 
   [s3]; comment
-  x =           a b        
+  x =           a b
 
 .. -> text
 
@@ -92,9 +92,9 @@ otherwise empty section) is blank.  For example:"
      'versions': {}}
 
 
-Sections headers can contain an optional arbitrary Python expression. 
+Sections headers can contain an optional arbitrary Python expression.
 When the expression evaluates to false the whole section is skipped.
-Several sections can have the same name with different expressions, enabling 
+Several sections can have the same name with different expressions, enabling
 conditional exclusion of sections::
 
   [s1: 2 + 2 == 4] # this expression is true [therefore "this section" _will_ be NOT skipped
@@ -106,7 +106,7 @@ conditional exclusion of sections::
   [   s2 : 41 + 1 == 42  ]  # a comment: this expression is [true], so this section will be kept
   long = b
 
-  [s3:2 in map(lambda i:i*2, [i for i in range(10)])] ;# Complex expressions are [possible!];, though they should not be (abused:) 
+  [s3:2 in map(lambda i:i*2, [i for i in range(10)])] ;# Complex expressions are [possible!];, though they should not be (abused:)
   # this section will not be skipped
   long = c
 
@@ -117,11 +117,11 @@ conditional exclusion of sections::
 
 
 Title line optional trailing comments are separated by a hash '#' or semicolon
-';' character.  The expression is an arbitrary expression with one restriction: 
-it cannot contain a literal hash '#' or semicolon ';' character: these need to be 
+';' character.  The expression is an arbitrary expression with one restriction:
+it cannot contain a literal hash '#' or semicolon ';' character: these need to be
 string-escaped.
-The comment can contain arbitrary characters, including brackets that are also 
-used to mark the end of a section header and may be ambiguous to recognize in 
+The comment can contain arbitrary characters, including brackets that are also
+used to mark the end of a section header and may be ambiguous to recognize in
 some cases. For example, valid sections lines include::
 
   [ a ]
@@ -170,7 +170,7 @@ some cases. For example, valid sections lines include::
 
 
 
-A title line optional trailing comment be separated by a hash or semicolon 
+A title line optional trailing comment be separated by a hash or semicolon
 character. The following are valid semicolon-separated comments::
 
   [ a ]  ;semicolon comment are supported for lines without expressions ]
@@ -226,10 +226,10 @@ The following sections with hash comment separators are valid too::
      'e': {'e': '1'}}
 
 
-However, explicit semicolon and hash characters are invalid in expressions and 
+However, explicit semicolon and hash characters are invalid in expressions and
 must be escaped or this triggers an error. In the rare case where a hash '#' or
-semicolon ';' would be needed in an expression literal, you can use the 
-string-escaped representation of these characters:  use '\x23' for hash '#' and 
+semicolon ';' would be needed in an expression literal, you can use the
+string-escaped representation of these characters:  use '\x23' for hash '#' and
 '\x3b' for semicolon ';' to avoid evaluation errors.
 These expressions are valid and use escaped hash and semicolons in literals::
 
@@ -256,11 +256,11 @@ And using unescaped semicolon and hash characters in expressions triggers an err
     ... except zc.buildout.configparser.MissingSectionHeaderError: pass # success
 
 
-One of the typical usage of expression is to have buildout parts that are 
-operating system or platform-specific.  The configparser.parse function has an 
-optional exp_globals argument.  This is a callable returning a mapping of 
-objects made available to the evaluation context of the expression. Here we add 
-the platform and sys modules to the evaluation context, so we can access 
+One of the typical usage of expression is to have buildout parts that are
+operating system or platform-specific.  The configparser.parse function has an
+optional exp_globals argument.  This is a callable returning a mapping of
+objects made available to the evaluation context of the expression. Here we add
+the platform and sys modules to the evaluation context, so we can access
 platform and sys modules functions and objects in our expressions ::
 
   [s1: str(platform.python_version_tuple()[0]) in ('2', '3',)] # this expression is true, the major versions of python are either 2 or 3
@@ -280,8 +280,8 @@ platform and sys modules functions and objects in our expressions ::
     {'s1': {'a': '1'}, 's2': {'long': 'b'}}
 
 
-Some limited (but hopefully sane and sufficient) default modules and 
-pre-computed common expressions available to an expression when the parser in 
+Some limited (but hopefully sane and sufficient) default modules and
+pre-computed common expressions available to an expression when the parser in
 called by buildout::
 
 
@@ -290,20 +290,20 @@ called by buildout::
   a = 1
 
   # major and minor python versions, yes even python 3.5 and 3.6 are there , prospectively
-  # comment: this expression "is true" and not that long expression cannot span several lines 
-  [s2: any([python2, python3, python24 , python25 , python26 , python27 , python30 , python31 , python32 , python33 , python34 , python35 , python36]) ] 
+  # comment: this expression "is true" and not that long expression cannot span several lines
+  [s2: any([python2, python3, python24 , python25 , python26 , python27 , python30 , python31 , python32 , python33 , python34 , python35 , python36]) ]
   b = 1
 
   # common python interpreter types
   [s3:cpython or pypy or jython or ironpython]  # a comment: this expression is likely always true, so this section will be kept
-  c = 1 
+  c = 1
 
   # common operating systems
-  [s4:linux or windows or cygwin or macosx or solaris or posix or True]  
+  [s4:linux or windows or cygwin or macosx or solaris or posix or True]
   d = 1
 
   # common bitness and endianness
-  [s5:bits32 or bits64 or little_endian or big_endian]  
+  [s5:bits32 or bits64 or little_endian or big_endian]
   e = 1
 
 .. -> text

--- a/src/zc/buildout/download.py
+++ b/src/zc/buildout/download.py
@@ -20,25 +20,8 @@ except ImportError:
 
 try:
     # Python 3
-    from urllib.request import FancyURLopener, URLopener, urlretrieve
+    from urllib.request import urlretrieve
     from urllib.parse import urlparse
-    from urllib import request
-    import warnings
-
-    class PatchedURLopener(FancyURLopener):
-        http_error_default = URLopener.http_error_default
-
-        def __init__(self, *args, **kwargs):
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
-                # This creates a DeprecationWarning on 3.6:
-                # PatchedURLopener style of invoking requests is deprecated.
-                # Use newer urlopen functions/methods.
-                # Said warning breaks our doctests.
-                super(PatchedURLopener, self).__init__(*args, **kwargs)
-
-    request._urlopener = PatchedURLopener()  # Ook! Monkey patch!
-
 except ImportError:
     # Python 2
     import base64

--- a/src/zc/buildout/download.py
+++ b/src/zc/buildout/download.py
@@ -23,9 +23,19 @@ try:
     from urllib.request import FancyURLopener, URLopener, urlretrieve
     from urllib.parse import urlparse
     from urllib import request
+    import warnings
 
     class PatchedURLopener(FancyURLopener):
         http_error_default = URLopener.http_error_default
+
+        def __init__(self, *args, **kwargs):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                # This creates a DeprecationWarning on 3.6:
+                # PatchedURLopener style of invoking requests is deprecated.
+                # Use newer urlopen functions/methods.
+                # Said warning breaks our doctests.
+                super(PatchedURLopener, self).__init__(*args, **kwargs)
 
     request._urlopener = PatchedURLopener()  # Ook! Monkey patch!
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -63,7 +63,7 @@ default_index_url = os.environ.get(
 logger = logging.getLogger('zc.buildout.easy_install')
 
 url_match = re.compile('[a-z0-9+.-]+://').match
-is_source_encoding_line = re.compile('coding[:=]\s*([-\w.]+)').search
+is_source_encoding_line = re.compile(r'coding[:=]\s*([-\w.]+)').search
 # Source encoding regex from http://www.python.org/dev/peps/pep-0263/
 
 is_win32 = sys.platform == 'win32'
@@ -634,7 +634,7 @@ class Installer:
         if dist_needs_pkg_resources(dist):
             # We have a namespace package but no requirement for setuptools
             if dist.precedence == pkg_resources.DEVELOP_DIST:
-                logger.warn(
+                logger.warning(
                     "Develop distribution: %s\n"
                     "uses namespace packages but the distribution "
                     "does not require setuptools.",

--- a/src/zc/buildout/repeatable.txt
+++ b/src/zc/buildout/repeatable.txt
@@ -397,7 +397,7 @@ at the end.
 
 The versions file now contains the extra pin:
 
-    >>> print_(open('my_versions.cfg').read()) # doctest: +ELLIPSIS
+    >>> with open('my_versions.cfg') as f: print_(f.read()) # doctest: +ELLIPSIS
     <BLANKLINE>
     ...
     # Added by buildout at YYYY-MM-DD hh:mm:ss.dddddd
@@ -437,7 +437,7 @@ printing them to the console):
 
 The versions file contains the extra pin:
 
-    >>> print_(open('my_versions.cfg').read()) # doctest: +ELLIPSIS
+    >>> with open('my_versions.cfg') as f: print_(f.read()) # doctest: +ELLIPSIS
     <BLANKLINE>
     [versions]
     ...

--- a/src/zc/buildout/rmtree.py
+++ b/src/zc/buildout/rmtree.py
@@ -40,7 +40,7 @@ def rmtree (path):
     Now create a file ...
 
     >>> foo = os.path.join (d, 'foo')
-    >>> _ = open (foo, 'w').write ('huhu')
+    >>> with open (foo, 'w') as f: _ = f.write ('huhu')
 
     and make it unwriteable
 
@@ -75,4 +75,3 @@ def test_suite():
 
 if "__main__" == __name__:
     doctest.testmod()
-

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -380,9 +380,10 @@ setup(name=%r, version=%r,
 
 def make_dist_that_requires(dest, name, requires=[], version=1, egg=''):
     os.mkdir(os.path.join(dest, name))
-    open(os.path.join(dest, name, 'setup.py'), 'w').write(
-        make_dist_that_requires_setup_py_template
-        % (name, version, requires)
+    with open(os.path.join(dest, name, 'setup.py'), 'w') as f:
+        f.write(
+            make_dist_that_requires_setup_py_template
+            % (name, version, requires)
         )
 
 def show_who_requires_when_there_is_a_conflict():
@@ -616,7 +617,7 @@ the comparison with the saved value works correctly.
     ...         options['format'] = '%3d'
     ...
     ...     def install(self):
-    ...         open('t', 'w').write('t')
+    ...         with open('t', 'w') as f: f.write('t')
     ...         return 't'
     ...
     ...     update = install
@@ -2002,6 +2003,7 @@ if sys.version_info > (2, 4):
         ...     p.stdin.close()
         ...     print_(p.stdout.read().decode())
         ...     print_('Exit:', bool(p.wait()))
+        ...     p.stdout.close()
 
         >>> call(buildout)
         <BLANKLINE>
@@ -2336,11 +2338,12 @@ def create_egg(name, version, dest, install_requires=None,
     else:
         requires = ''
     try:
-        open(os.path.join(d, 'setup.py'), 'w').write(
-            'from setuptools import setup\n'
-            'setup(name=%r, version=%r, extras_require=%r, zip_safe=True,\n'
-            '      %s %s py_modules=["setup"]\n)'
-            % (name, str(version), extras, requires, links)
+        with open(os.path.join(d, 'setup.py'), 'w') as f:
+            f.write(
+                'from setuptools import setup\n'
+                'setup(name=%r, version=%r, extras_require=%r, zip_safe=True,\n'
+                '      %s %s py_modules=["setup"]\n)'
+                % (name, str(version), extras, requires, links)
             )
         zc.buildout.testing.bdist_egg(d, sys.executable, os.path.abspath(dest))
     finally:
@@ -2786,7 +2789,8 @@ def make_sure_versions_dont_cancel_extras():
     """
     There was a bug that caused extras in requirements to be lost.
 
-    >>> _ = open('setup.py', 'w').write('''
+    >>> with open('setup.py', 'w') as f:
+    ...    _ = f.write('''
     ... from setuptools import setup
     ... setup(name='extraversiondemo', version='1.0',
     ...       url='x', author='x', author_email='x',
@@ -3478,7 +3482,7 @@ def buildout_txt_setup(test):
         os.path.join(eggs, 'zc.recipe.egg'),
         )
 
-egg_parse = re.compile('([0-9a-zA-Z_.]+)-([0-9a-zA-Z_.]+)-py(\d[.]\d).egg$'
+egg_parse = re.compile(r'([0-9a-zA-Z_.]+)-([0-9a-zA-Z_.]+)-py(\d[.]\d).egg$'
                        ).match
 def makeNewRelease(project, ws, dest, version='99.99'):
     dist = ws.find(pkg_resources.Requirement.parse(project))
@@ -3500,9 +3504,11 @@ def makeNewRelease(project, ws, dest, version='99.99'):
     else:
         shutil.copytree(dist.location, dest)
         info_path = os.path.join(dest, 'EGG-INFO', 'PKG-INFO')
-        info = open(info_path).read().replace("Version: %s" % oldver,
-                                              "Version: %s" % version)
-        open(info_path, 'w').write(info)
+        with open(info_path) as f:
+            info = f.read().replace("Version: %s" % oldver,
+                                    "Version: %s" % version)
+        with open(info_path, 'w') as f:
+            f.write(info)
 
 def getWorkingSetWithBuildoutEgg(test):
     sample_buildout = test.globs['sample_buildout']
@@ -3578,7 +3584,9 @@ normalize_S = (
     '#!/usr/local/bin/python2.7',
     )
 
+
 def test_suite():
+
     test_suite = [
         manuel.testing.TestSuite(
             manuel.doctest.Manuel() + manuel.capture.Manuel(),
@@ -3594,17 +3602,17 @@ def test_suite():
                     zc.buildout.testing.not_found,
                     zc.buildout.testing.adding_find_link,
                     # (re.compile(r"Installing 'zc.buildout >=\S+"), ''),
-                    (re.compile('__buildout_signature__ = recipes-\S+'),
+                    (re.compile(r'__buildout_signature__ = recipes-\S+'),
                      '__buildout_signature__ = recipes-SSSSSSSSSSS'),
-                    (re.compile('executable = [\S ]+python\S*', re.I),
+                    (re.compile(r'executable = [\S ]+python\S*', re.I),
                      'executable = python'),
-                    (re.compile('[-d]  (setuptools|setuptools)-\S+[.]egg'),
+                    (re.compile(r'[-d]  (setuptools|setuptools)-\S+[.]egg'),
                      'setuptools.egg'),
-                    (re.compile('zc.buildout(-\S+)?[.]egg(-link)?'),
+                    (re.compile(r'zc.buildout(-\S+)?[.]egg(-link)?'),
                      'zc.buildout.egg'),
-                    (re.compile('creating \S*setup.cfg'), 'creating setup.cfg'),
-                    (re.compile('hello\%ssetup' % os.path.sep), 'hello/setup'),
-                    (re.compile('Picked: (\S+) = \S+'),
+                    (re.compile(r'creating \S*setup.cfg'), 'creating setup.cfg'),
+                    (re.compile(r'hello\%ssetup' % os.path.sep), 'hello/setup'),
+                    (re.compile(r'Picked: (\S+) = \S+'),
                      'Picked: \\1 = V.V'),
                     (re.compile(r'We have a develop egg: zc.buildout (\S+)'),
                      'We have a develop egg: zc.buildout X.X.'),
@@ -3615,7 +3623,7 @@ def test_suite():
                      '[Errno 17] File exists: '
                      ),
                     (re.compile('setuptools'), 'setuptools'),
-                    (re.compile('Got zc.recipe.egg \S+'), 'Got zc.recipe.egg'),
+                    (re.compile(r'Got zc.recipe.egg \S+'), 'Got zc.recipe.egg'),
                     (re.compile(r'zc\.(buildout|recipe\.egg)\s*= >=\S+'),
                      'zc.\\1 = >=1.99'),
                     ])
@@ -3639,20 +3647,20 @@ def test_suite():
                # (re.compile(r"Installing 'zc.buildout >=\S+"), ''),
                # (re.compile(r"Getting distribution for 'zc.buildout >=\S+"),
                #  ''),
-               (re.compile('__buildout_signature__ = recipes-\S+'),
+               (re.compile(r'__buildout_signature__ = recipes-\S+'),
                 '__buildout_signature__ = recipes-SSSSSSSSSSS'),
-               (re.compile('[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
-               (re.compile('zc.buildout(-\S+)?[.]egg(-link)?'),
+               (re.compile(r'[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
+               (re.compile(r'zc.buildout(-\S+)?[.]egg(-link)?'),
                 'zc.buildout.egg'),
-               (re.compile('creating \S*setup.cfg'), 'creating setup.cfg'),
-               (re.compile('hello\%ssetup' % os.path.sep), 'hello/setup'),
-               (re.compile('Picked: (\S+) = \S+'),
+               (re.compile(r'creating \S*setup.cfg'), 'creating setup.cfg'),
+               (re.compile(r'hello\%ssetup' % os.path.sep), 'hello/setup'),
+               (re.compile(r'Picked: (\S+) = \S+'),
                 'Picked: \\1 = V.V'),
                (re.compile(r'We have a develop egg: zc.buildout (\S+)'),
                 'We have a develop egg: zc.buildout X.X.'),
                (re.compile(r'\\[\\]?'), '/'),
-               (re.compile('WindowsError'), 'OSError'),
-               (re.compile('setuptools = \S+'), 'setuptools = 0.7.99'),
+               (re.compile(r'WindowsError'), 'OSError'),
+               (re.compile(r'setuptools = \S+'), 'setuptools = 0.7.99'),
                (re.compile(r'\[Error 17\] Cannot create a file '
                            r'when that file already exists: '),
                 '[Errno 17] File exists: '
@@ -3688,7 +3696,7 @@ def test_suite():
             optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
             checker=renormalizing.RENormalizing([
                 (re.compile(r'(zc.buildout|setuptools)-\d+[.]\d+\S*'
-                            '-py\d.\d.egg'),
+                            r'-py\d.\d.egg'),
                  '\\1.egg'),
                 zc.buildout.testing.normalize_path,
                 zc.buildout.testing.normalize_endings,
@@ -3726,7 +3734,7 @@ def test_suite():
                 zc.buildout.testing.not_found,
                 normalize_bang,
                 normalize_S,
-                (re.compile('[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
+                (re.compile(r'[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
                 (re.compile(r'\\[\\]?'), '/'),
                 (re.compile('(\n?)-  ([a-zA-Z_.-]+)\n-  \\2.exe\n'),
                  '\\1-  \\2\n'),
@@ -3771,18 +3779,18 @@ def test_suite():
                 zc.buildout.testing.adding_find_link,
                 normalize_bang,
                 (re.compile(r'^(\w+\.)*(Missing\w+: )'), '\2'),
-                (re.compile("buildout: Running \S*setup.py"),
+                (re.compile(r"buildout: Running \S*setup.py"),
                  'buildout: Running setup.py'),
-                (re.compile('setuptools-\S+-'),
+                (re.compile(r'setuptools-\S+-'),
                  'setuptools.egg'),
-                (re.compile('zc.buildout-\S+-'),
+                (re.compile(r'zc.buildout-\S+-'),
                  'zc.buildout.egg'),
-                (re.compile('setuptools = \S+'), 'setuptools = 0.7.99'),
-                (re.compile('File "\S+one.py"'),
+                (re.compile(r'setuptools = \S+'), 'setuptools = 0.7.99'),
+                (re.compile(r'File "\S+one.py"'),
                  'File "one.py"'),
                 (re.compile(r'We have a develop egg: (\S+) (\S+)'),
                  r'We have a develop egg: \1 V'),
-                (re.compile('Picked: setuptools = \S+'),
+                (re.compile(r'Picked: setuptools = \S+'),
                  'Picked: setuptools = V'),
                 (re.compile('[-d]  setuptools'), '-  setuptools'),
                 (re.compile(r'\\[\\]?'), '/'),
@@ -3816,14 +3824,14 @@ def test_suite():
                zc.buildout.testing.normalize_egg_py,
                zc.buildout.testing.not_found,
                zc.buildout.testing.adding_find_link,
-               (re.compile('__buildout_signature__ = recipes-\S+'),
+               (re.compile(r'__buildout_signature__ = recipes-\S+'),
                 '__buildout_signature__ = recipes-SSSSSSSSSSS'),
-               (re.compile('[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
-               (re.compile('zc.buildout(-\S+)?[.]egg(-link)?'),
+               (re.compile(r'[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
+               (re.compile(r'zc.buildout(-\S+)?[.]egg(-link)?'),
                 'zc.buildout.egg'),
-               (re.compile('creating \S*setup.cfg'), 'creating setup.cfg'),
-               (re.compile('hello\%ssetup' % os.path.sep), 'hello/setup'),
-               (re.compile('Picked: (\S+) = \S+'),
+               (re.compile(r'creating \S*setup.cfg'), 'creating setup.cfg'),
+               (re.compile(r'hello\%ssetup' % os.path.sep), 'hello/setup'),
+               (re.compile(r'Picked: (\S+) = \S+'),
                 'Picked: \\1 = V.V'),
                (re.compile(r'We have a develop egg: zc.buildout (\S+)'),
                 'We have a develop egg: zc.buildout X.X.'),

--- a/src/zc/buildout/windows.txt
+++ b/src/zc/buildout/windows.txt
@@ -28,7 +28,7 @@ can't delete.
     ...             os.makedirs (self.location)
     ...
     ...         name = os.path.join (self.location, 'readonly.txt')
-    ...         open (name, 'w').write ('this is a read only file')
+    ...         with open (name, 'w') as f: f.write ('this is a read only file')
     ...         os.chmod(name, 256)
     ...         return ()
     ...

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
     # buildout's dev.py wants python to not have setuptools
     pip uninstall -y zc.buildout setuptools pip
     python dev.py
-    {toxinidir}/bin/test -1 -v -c
+    {toxinidir}/bin/test -1 -vvv -c
     coverage combine
     coverage report
 # since we're removing setuptools we can't possibly reuse the virtualenv

--- a/zc.recipe.egg_/setup.py
+++ b/zc.recipe.egg_/setup.py
@@ -20,7 +20,8 @@ import os
 from setuptools import setup, find_packages
 
 def read(*rnames):
-    return open(os.path.join(os.path.dirname(__file__), *rnames)).read()
+    with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
+        return f.read()
 
 name = "zc.recipe.egg"
 setup(

--- a/zc.recipe.egg_/src/zc/recipe/egg/egg.py
+++ b/zc.recipe.egg_/src/zc/recipe/egg/egg.py
@@ -214,7 +214,7 @@ class Scripts(Eggs):
             assert relative_paths == 'false'
 
     parse_entry_point = re.compile(
-        '([^=]+)=(\w+(?:[.]\w+)*):(\w+(?:[.]\w+)*)$'
+        r'([^=]+)=(\w+(?:[.]\w+)*):(\w+(?:[.]\w+)*)$'
         ).match
 
     def install(self):

--- a/zc.recipe.egg_/src/zc/recipe/egg/tests.py
+++ b/zc.recipe.egg_/src/zc/recipe/egg/tests.py
@@ -50,9 +50,9 @@ def test_suite():
                zc.buildout.tests.normalize_bang,
                zc.buildout.tests.normalize_S,
                zc.buildout.testing.not_found,
-               (re.compile('[d-]  zc.buildout(-\S+)?[.]egg(-link)?'),
+               (re.compile(r'[d-]  zc.buildout(-\S+)?[.]egg(-link)?'),
                 'zc.buildout.egg'),
-               (re.compile('[d-]  setuptools-[^-]+-'), 'setuptools-X-'),
+               (re.compile(r'[d-]  setuptools-[^-]+-'), 'setuptools-X-'),
                (re.compile(r'eggs\\\\demo'), 'eggs/demo'),
                (re.compile(r'[a-zA-Z]:\\\\foo\\\\bar'), '/foo/bar'),
                ])
@@ -66,15 +66,15 @@ def test_suite():
                zc.buildout.testing.normalize_endings,
                zc.buildout.testing.not_found,
                (re.compile('__buildout_signature__ = '
-                           'sample-\S+\s+'
-                           'zc.recipe.egg-\S+\s+'
-                           'setuptools-\S+\s+'
-                           'zc.buildout-\S+\s*'
+                           r'sample-\S+\s+'
+                           r'zc.recipe.egg-\S+\s+'
+                           r'setuptools-\S+\s+'
+                           r'zc.buildout-\S+\s*'
                            ),
                 '__buildout_signature__ = sample- zc.recipe.egg-'),
-               (re.compile('find-links = http://localhost:\d+/'),
+               (re.compile(r'find-links = http://localhost:\d+/'),
                 'find-links = http://localhost:8080/'),
-               (re.compile('index = http://localhost:\d+/index'),
+               (re.compile(r'index = http://localhost:\d+/index'),
                 'index = http://localhost:8080/index'),
                ])
             ),
@@ -87,7 +87,7 @@ def test_suite():
                 zc.buildout.testing.normalize_endings,
                 zc.buildout.testing.not_found,
                 (re.compile("(d  ((ext)?demo(needed)?|other)"
-                            "-\d[.]\d-py)\d[.]\d(-\S+)?[.]egg"),
+                            r"-\d[.]\d-py)\d[.]\d(-\S+)?[.]egg"),
                  '\\1V.V.egg'),
                 (re.compile('extdemo.c\n.+\\\\extdemo.exp\n'), ''),
                 (re.compile(


### PR DESCRIPTION
On Python 3, these made the build output very hard to read (e.g., https://travis-ci.org/buildout/buildout/jobs/394026829)

On Python 3.7, these could actually break the doctests.

Closing the files should get us closer to being able to pass the tests with PyPy.