### PR TITLE
debugger: Exit with error code on debugged error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change History
 2.12.2 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Exit program with error code on error when running with ``-D``.
 
 
 2.12.1 (2018-07-02)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -2149,7 +2149,7 @@ def main(args=None):
                 else:
                     sys.stderr.write(_internal_error_template)
                     traceback.print_exception(*exc_info)
-                    sys.exit(1)
+            sys.exit(1)
 
     finally:
         logging.shutdown()

--- a/src/zc/buildout/debugging.txt
+++ b/src/zc/buildout/debugging.txt
@@ -56,12 +56,13 @@ And create a buildout that uses it:
 
 If we run the buildout, we'll get an error:
 
-    >>> print_(system(buildout), end='')
+    >>> print_(system(buildout, with_exit_code=True), end='')
     Develop: '/sample-buildout/recipes'
     Installing data-dir.
     While:
       Installing data-dir.
     Error: Missing option: data-dir:directory
+    EXIT CODE: 1
 
 
 If we want to debug the error, we can add the -D option. Here's we'll
@@ -71,7 +72,7 @@ supply some input:
     ... up
     ... p sorted(self.options.keys())
     ... q
-    ... """), end='')
+    ... """, with_exit_code=True), end='')
     Develop: '/sample-buildout/recipes'
     Installing data-dir.
     > /zc/buildout/buildout.py(925)__getitem__()
@@ -95,3 +96,4 @@ supply some input:
     MissingOption: Missing option: data-dir:directory
     <BLANKLINE>
     Starting pdb:
+    EXIT CODE: 1


### PR DESCRIPTION
When buildout encounter an error, program exists with error code 1, this
should also be the case when exiting from a debugger session when
running with -D option.