### PR TITLE
Avoid DeprecationWarning: 'U' mode is deprecated (Version 2)

### DIFF
--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1467,15 +1467,20 @@ def _pyscript(path, dest, rsetup, initialization=''):
     generated.append(dest)
     return generated
 
+if sys.version_info[0] < 3:
+    universal_newline_option = ", 'U'"
+else:
+    universal_newline_option = ''
+
 py_script_template = script_header + '''\
 
-%(relative_paths_setup)s
+%%(relative_paths_setup)s
 import sys
 
 sys.path[0:0] = [
-  %(path)s
+  %%(path)s
   ]
-%(initialization)s
+%%(initialization)s
 
 _interactive = True
 if len(sys.argv) > 1:
@@ -1496,13 +1501,13 @@ if len(sys.argv) > 1:
         sys.argv[:] = _args
         __file__ = _args[0]
         del _options, _args
-        with open(__file__, 'U') as __file__f:
+        with open(__file__%s) as __file__f:
             exec(compile(__file__f.read(), __file__, "exec"))
 
 if _interactive:
     del _interactive
     __import__("code").interact(banner="", local=globals())
-'''
+''' % universal_newline_option
 
 runsetup_template = """
 import sys
@@ -1516,9 +1521,9 @@ __file__ = %%(__file__)r
 os.chdir(%%(setupdir)r)
 sys.argv[0] = %%(setup)r
 
-with open(%%(setup)r, 'U') as f:
+with open(%%(setup)r%s) as f:
     exec(compile(f.read(), %%(setup)r, 'exec'))
-""" % setuptools_path
+""" % (setuptools_path, universal_newline_option)
 
 
 class VersionConflict(zc.buildout.UserError):

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -132,18 +132,6 @@ def system(command, input='', with_exit_code=False):
     # http://bugs.python.org/issue19884
     env = dict(os.environ, TERM='dumb')
 
-    # Beginning in Python 3.4, 'U' mode to open() is deprecated.
-    # Python 3.7 changes the way deprecations are shown for main
-    # modules, and introduces $PYTHONDEVMODE which turns on warnigs in
-    # more places. If that's done, this leads many of our doctests to
-    # break; some code path through executing setup.py does this, but
-    # it's not in our code. Unfortunately, normalizing this printed
-    # line away doesn't work, it just produces a blank line. We resort
-    # to turning that warning off.
-    warnings = env.get('PYTHONWARNINGS', '')
-    env['PYTHONWARNINGS'] = "ignore:'U' mode is deprecated:DeprecationWarning::," + warnings
-
-
     p = subprocess.Popen(command,
                          shell=True,
                          stdin=subprocess.PIPE,

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -606,6 +606,9 @@ normalize_exception_type_for_python_2_and_3 = (
     re.compile(r'^(\w+\.)*([A-Z][A-Za-z0-9]+Error: )'),
     '\2')
 
+normalize_open_in_generated_script = (
+    re.compile(r"open\(__file__, 'U'\)"), 'open(__file__)')
+
 not_found = (re.compile(r'Not found: [^\n]+/(\w|\.)+/\r?\n'), '')
 
 # Setuptools now pulls in dependencies when installed.

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -3730,6 +3730,7 @@ def test_suite():
                 zc.buildout.testing.normalize_endings,
                 zc.buildout.testing.normalize_egg_py,
                 zc.buildout.testing.normalize_exception_type_for_python_2_and_3,
+                zc.buildout.testing.normalize_open_in_generated_script,
                 zc.buildout.testing.adding_find_link,
                 zc.buildout.testing.not_found,
                 normalize_bang,


### PR DESCRIPTION
Fixes #466.

This is #476 by @lrowe + fixed tests by @mgedmin.
Maybe this PR can be merged because the warnings produced by `buildout` are daily annoying me.