### PR TITLE
Use Github Actions for smoke tests

### DIFF
--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -1,0 +1,7 @@
+sandbox/bin/python:
+	pip install virtualenv
+	virtualenv sandbox
+
+sandbox/bin/buildout: sandbox/bin/python
+	sandbox/bin/python setup.py develop
+

--- a/.github/workflows/scripts.cfg
+++ b/.github/workflows/scripts.cfg
@@ -1,0 +1,15 @@
+[buildout]
+extensions = buildout.environ
+environ-required =
+    PACKAGE
+
+parts = test
+
+sandbox = ${buildout:directory}/../../sandbox
+eggs-directory = ${buildout:sandbox}/eggs
+download-cache = ${buildout:sandbox}/downloads
+abi-tag-eggs = false
+
+[test]
+recipe = zc.recipe.egg
+eggs = ${__environ__:PACKAGE}

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,0 +1,33 @@
+name: Test generating scripts
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+        package: [zest.releaser, pyspf]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup buildout virtualenv
+      run: |
+        make -f .github/workflows/Makefile sandbox/bin/buildout
+    - name: Run buildout
+      env:
+        PACKAGE: ${{matrix.package}}
+      run: |
+        sandbox/bin/buildout -v -c .github/workflows/scripts.cfg annotate buildout
+        sandbox/bin/buildout -c .github/workflows/scripts.cfg
+    - name: Check eggs
+      run: |
+        ls -al sandbox/eggs
+        ls -al sandbox/downloads/dist

--- a/.github/workflows/setuptools-master.yml
+++ b/.github/workflows/setuptools-master.yml
@@ -1,0 +1,48 @@
+name: Test generating scripts with setuptools head
+
+on:
+  schedule:
+    - cron:  '0 0,12 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+        package: [zest.releaser, pyspf]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: checkout setuptools
+      run: |
+        git clone https://github.com/pypa/setuptools.git
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Setup buildout virtualenv
+      run: |
+        make -f .github/workflows/Makefile sandbox/bin/buildout
+    - name: Use setuptools develop
+      env:
+        PYTHON_VERSION: ${{matrix.python-version}}
+      run: |
+        ./sandbox/bin/pip uninstall -y setuptools
+        cd setuptools
+        ../sandbox/bin/python bootstrap.py
+        ../sandbox/bin/python setup.py develop
+        ls ../sandbox/lib/python${PYTHON_VERSION}/site-packages
+    - name: Run buildout
+      env:
+        PACKAGE: ${{matrix.package}}
+      run: |
+        sandbox/bin/buildout -v -c .github/workflows/scripts.cfg annotate buildout
+        sandbox/bin/buildout -c .github/workflows/scripts.cfg
+    - name: Check eggs
+      run: |
+        ls -al sandbox/eggs
+        ls -al sandbox/downloads/dist
+


### PR DESCRIPTION
Travis builds are broken. So we are not warned, among others, about changes in setuptools.

`setuptools 42.0.1` breaks our tests. See #493 

I also made smoke tests.