### PR TITLE
Problem: Does not complain for typo in 'scripts'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change History
 3.0.0a2 (unreleased)
 ====================
 
+- Warn when a script name passed in 'scripts' argument of easy_install.scripts
+  is not defined in egg entry points.
+
 - Show only once pip warning about python version.
 
 - Better patch for ``pkg_resources.Distribution.hashcmp`` performance.

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -1203,7 +1203,10 @@ def scripts(reqs, working_set, executable, dest=None,
         else:
             entry_points.append(req)
 
+    entry_points_names = []
+
     for name, module_name, attrs in entry_points:
+        entry_points_names.append(name)
         if scripts is not None:
             sname = scripts.get(name)
             if sname is None:
@@ -1218,6 +1221,18 @@ def scripts(reqs, working_set, executable, dest=None,
             _script(module_name, attrs, spath, sname, arguments,
                     initialization, rpsetup)
             )
+
+    # warn when a script name passed in 'scripts' argument
+    # is not defined in an entry point.
+    if scripts is not None:
+        for name, target in scripts.items():
+            if name not in entry_points_names:
+                if name == target:
+                    logger.warning("Could not generate script '%s' as it is not "
+                        "defined in the egg entry points.", name)
+                else:
+                    logger.warning("Could not generate script '%s' as script "
+                        "'%s' is not defined in the egg entry points.", name, target)
 
     for name, contents in distutils_scripts:
         if scripts is not None:

--- a/zc.recipe.egg_/src/zc/recipe/egg/README.rst
+++ b/zc.recipe.egg_/src/zc/recipe/egg/README.rst
@@ -346,6 +346,48 @@ You can also control the name used for scripts:
     -  buildout
     -  foo
 
+If a wrong script name is provided, buildout tells about it:
+
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = demo
+    ...
+    ... [demo]
+    ... recipe = zc.recipe.egg
+    ... find-links = %(server)s
+    ... index = %(server)s/index
+    ... scripts = undefined
+    ... """ % dict(server=link_server))
+
+    >>> print system(buildout),
+    Uninstalling demo.
+    Installing demo.
+    Could not generate script 'undefined' as it is not defined in the egg entry points.
+
+    >>> ls(sample_buildout, 'bin')
+    -  buildout
+
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = demo
+    ...
+    ... [demo]
+    ... recipe = zc.recipe.egg
+    ... find-links = %(server)s
+    ... index = %(server)s/index
+    ... scripts = foo=undefined
+    ... """ % dict(server=link_server))
+
+    >>> print system(buildout),
+    Uninstalling demo.
+    Installing demo.
+    Could not generate script 'foo' as script 'undefined' is not defined in the egg entry points.
+
+    >>> ls(sample_buildout, 'bin')
+    -  buildout
+
 Specifying extra script paths
 -----------------------------
 


### PR DESCRIPTION
Solution: Warn when a script name passed in 'scripts' argument of easy_install.scripts
is not defined in egg entry points.

10 years old patch 😬 