### PR TITLE
ignore git when computing signature of a recipe develop egg

### DIFF
--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1835,7 +1835,7 @@ def _open(base, filename, seen, dl_options, override, downloaded):
     return result
 
 
-ignore_directories = '.svn', 'CVS', '__pycache__'
+ignore_directories = '.svn', 'CVS', '__pycache__', '.git'
 _dir_hashes = {}
 def _dir_hash(dir):
     dir_hash = _dir_hashes.get(dir, None)

--- a/src/zc/buildout/tests.py
+++ b/src/zc/buildout/tests.py
@@ -1236,7 +1236,7 @@ def changes_in_svn_or_CVS_dont_affect_sig():
     """
 
 If we have a develop recipe, it's signature shouldn't be affected to
-changes in .svn or CVS directories.
+changes in .git, .svn or CVS directories.
 
     >>> mkdir('recipe')
     >>> write('recipe', 'setup.py',
@@ -1268,12 +1268,14 @@ changes in .svn or CVS directories.
     Develop: '/sample-buildout/recipe'
     Installing foo.
 
+    >>> mkdir('recipe', '.git')
     >>> mkdir('recipe', '.svn')
     >>> mkdir('recipe', 'CVS')
     >>> print_(system(join(sample_buildout, 'bin', 'buildout')), end='')
     Develop: '/sample-buildout/recipe'
     Updating foo.
 
+    >>> write('recipe', '.git', 'x', '1')
     >>> write('recipe', '.svn', 'x', '1')
     >>> write('recipe', 'CVS', 'x', '1')
 


### PR DESCRIPTION
When a recipe is developed in a git working copy, .git administrative
database folder should be ignored, like we did with CVS and svn.

fixes #522