### PR TITLE
Evaluate environment markers for requirement strings

### DIFF
--- a/doc/getting-started.rst
+++ b/doc/getting-started.rst
@@ -439,6 +439,39 @@ where you list them, as in:
 
 In this example, we've requested a version of bobo less than 5.0.
 
+You can also add `environment markers <https://python.org/dev/peps/pep-0496>`_
+to restrict some requirements to i.e. a certain platform or python version:
+
+.. code-block:: ini
+
+  [bobo]
+  recipe = zc.recipe.egg
+  eggs =
+      bobo ==2.2.0; python_version < '3.0'
+      bobo ==2.3.0; python_version >= '3.0'
+
+.. -> src
+
+   >>> prefix = """
+   ... [buildout]
+   ... parts = bobo
+   ... """
+   >>> with open('buildout.cfg', 'w') as f:
+   ...     _ = f.write(prefix)
+   ...     _ = f.write(src)
+
+   >>> import shutil
+   >>> import sys
+   >>> v = sys.version_info
+   >>> shutil.rmtree('eggs')
+   >>> run_buildout('buildout show-picked-versions=true')
+   >>> yup([n for n in ls('eggs') if n.startswith('bobo-2.3.0-')])\
+   ... if v.major >= 3 else\
+   ... yup([n for n in ls('eggs') if n.startswith('bobo-2.2.0-')])
+   >>> yup('bobo==2.3.0' in read('out'))\
+   ... if v.major >= 3 else\
+   ... yup('bobo==2.2.0' in read('out'))
+
 The more common way to pin a version is using a ``versions`` section:
 
 .. code-block:: ini

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -678,8 +678,14 @@ class Installer(object):
 
         for_buildout_run = bool(working_set)
 
-        requirements = [self._constrain(pkg_resources.Requirement.parse(spec))
+        requirements = [pkg_resources.Requirement.parse(spec)
                         for spec in specs]
+
+        requirements = [
+            self._constrain(requirement)
+            for requirement in requirements
+            if not requirement.marker or requirement.marker.evaluate()
+        ]
 
         if working_set is None:
             ws = pkg_resources.WorkingSet([])
@@ -1168,6 +1174,8 @@ def scripts(reqs, working_set, executable, dest=None,
     for req in reqs:
         if isinstance(req, str):
             req = pkg_resources.Requirement.parse(req)
+            if req.marker and not req.marker.evaluate():
+                continue
             dist = working_set.find(req)
             # regular console_scripts entry points
             for name in pkg_resources.get_entry_map(dist, 'console_scripts'):


### PR DESCRIPTION
support [environment markers](https://www.python.org/dev/peps/pep-0496), this way we can say things like

```
eggs =
    lib == version1; python_version >= '3.0'
    lib == version2; python_version < '3.0'
```