### PR TITLE
Fix urlretrieve for python3, support basic auth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Change History
 3.0.0a3 (unreleased)
 ====================
 
+- Fix python 3 urlretrieve for downloading external config files with basic
+  auth in the URL. Same as issue #257 for python 2 in release 2.5.1.
+
 - Support python37, python38 and python39 in conditional section expressions
 
 


### PR DESCRIPTION
Python 3, Basic Authentication support. This is used for downloads from private pypi server e.g.
buildout -c https://pypi.foobar.com/private/something.cfg

Same issue as #257 for python 2 in release 2.5.1.