### PR TITLE
update setuptools requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     namespace_packages = ['zc'],
     install_requires = [
-        'setuptools>=8.0',
+        'setuptools>=42.0.1,<52',
         'pip',
         'wheel',
     ],


### PR DESCRIPTION
setuptools is now pinned to >=42.0.1 and <52.

setuptools version 52 broke support for easy_install
https://github.com/pypa/setuptools/blob/main/CHANGES.rst#breaking-changes-1

setuptools>=42.0.1 is necessary so buildout can download e.g. latest
versions of `cryptography`, possibly related to
https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07
also see
https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v4201

fixes #544 also relates to #543 