### PR TITLE
Fix bootstrapping for Python 2.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,12 @@
 Change History
 **************
 
-2.13.x (unreleased)
-===================
-
-- Fix bootstrapping for python27
-
-
 3.0.0a3 (unreleased)
 ====================
 
 - Support python37, python38 and python39 in conditional section expressions
+
+- Fix bootstrapping for python27 and python35
 
 
 3.0.0a2 (2020-05-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Change History
 **************
 
+2.13.x (unreleased)
+===================
+
+- Fix bootstrapping for python27
+
+
 3.0.0a3 (unreleased)
 ====================
 

--- a/dev.py
+++ b/dev.py
@@ -52,8 +52,11 @@ def install_pip():
     tmp = tempfile.mkdtemp(prefix='buildout-dev-')
     try:
         get_pip = os.path.join(tmp, 'get-pip.py')
+        GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py'
+        if sys.version_info < (3, ):
+            GET_PIP_URL = 'https://bootstrap.pypa.io/2.7/get-pip.py'
         with open(get_pip, 'wb') as f:
-           f.write(urlopen('https://bootstrap.pypa.io/get-pip.py').read())
+            f.write(urlopen(GET_PIP_URL).read())
 
         sys.stdout.flush()
         if subprocess.call([sys.executable, get_pip]):

--- a/dev.py
+++ b/dev.py
@@ -86,7 +86,7 @@ def check_upgrade(package):
         output = subprocess.check_output(
             [sys.executable] + ['-m', 'pip', 'install', '--upgrade', package],
         )
-        was_up_to_date = b"up-to-date" in output
+        was_up_to_date = b"up-to-date" in output or b"already satisfied" in output
         if not was_up_to_date:
             print(output.decode('utf8'))
         return not was_up_to_date

--- a/dev.py
+++ b/dev.py
@@ -59,8 +59,7 @@ def install_pip():
         else:
             GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py'
         with open(get_pip, 'wb') as f:
-            with urlopen(GET_PIP_URL) as r:
-                f.write(r.read())
+            f.write(urlopen(GET_PIP_URL).read())
 
         sys.stdout.flush()
         if subprocess.call([sys.executable, get_pip]):

--- a/dev.py
+++ b/dev.py
@@ -52,11 +52,15 @@ def install_pip():
     tmp = tempfile.mkdtemp(prefix='buildout-dev-')
     try:
         get_pip = os.path.join(tmp, 'get-pip.py')
-        GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py'
         if sys.version_info < (3, ):
             GET_PIP_URL = 'https://bootstrap.pypa.io/2.7/get-pip.py'
+        elif (sys.version_info.major, sys.version_info.minor) == (3, 5):
+            GET_PIP_URL = 'https://bootstrap.pypa.io/3.5/get-pip.py'
+        else:
+            GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py'
         with open(get_pip, 'wb') as f:
-            f.write(urlopen(GET_PIP_URL).read())
+            with urlopen(GET_PIP_URL) as r:
+                f.write(r.read())
 
         sys.stdout.flush()
         if subprocess.call([sys.executable, get_pip]):


### PR DESCRIPTION
The bootstrap process uses `get-pip.py`, which in its latest version,
tries to bootstrap a Python 3 only version of pip.

We need to pass in a separate URL for a Python 2.7 compatible version of get-pip.py.

This should fix #546