### PR TITLE
update setuptools requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 2.13.4 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Pin `setuptools` < 52 as setuptools removed support for `easy_install` in
+  newer versions.
+  (`#543 <https://github.com/buildout/buildout/issues/543>`_)
 
 
 2.13.3 (2020-02-11)

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,7 @@ setup(
     packages = ['zc', 'zc.buildout'],
     package_dir = {'': 'src'},
     namespace_packages = ['zc'],
-    install_requires = [
-        'setuptools>=8.0',
-    ],
+    install_requires = ['setuptools>=8.0,<52',],
     include_package_data = True,
     entry_points = entry_points,
     extras_require = dict(


### PR DESCRIPTION
setuptools is now pinned to <52.

setuptools version 52 broke support for easy_install
https://github.com/pypa/setuptools/blob/main/CHANGES.rst#breaking-changes-1

info below is now invalid
```
setuptools>=42.0.1 is necessary so buildout can download e.g. latest
versions of `cryptography`, possibly related to
https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#34---2021-02-07
also see
https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v4201
```

This fixes #543