### PR TITLE
Problem: error message is not explicit when allow-picked-version = false

### DIFF
--- a/news/481.feature
+++ b/news/481.feature
@@ -1,0 +1,1 @@
+Improve error message when a package version is not pinned and `allow-picked-versions = false`.

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -635,10 +635,11 @@ class Installer(object):
                 self._picked_versions[dist.project_name] = dist.version
 
                 if not self._allow_picked_versions:
-                    raise zc.buildout.UserError(
-                        'Picked: %s = %s' % (dist.project_name,
-                                             dist.version)
-                        )
+                    msg = NOT_PICKED_AND_NOT_ALLOWED.format(
+                        name=dist.project_name,
+                        version=dist.version
+                    )
+                    raise zc.buildout.UserError(msg)
 
     def _maybe_add_setuptools(self, ws, dist):
         if dist_needs_pkg_resources(dist):
@@ -1946,3 +1947,17 @@ def sort_working_set(ws, eggs_dir, develop_eggs_dir):
     sorted_paths.extend(egg_paths)
     sorted_paths.extend(other_paths)
     return pkg_resources.WorkingSet(sorted_paths)
+
+
+NOT_PICKED_AND_NOT_ALLOWED = """\
+Picked: {name} = {version}
+
+The `{name}` egg does not have a version pin and `allow-picked-versions = false`.
+
+To resolve this, add
+
+    {name} = {version}
+
+to the [versions] section,
+
+OR set `allow-picked-versions = true`."""

--- a/src/zc/buildout/tests/easy_install.txt
+++ b/src/zc/buildout/tests/easy_install.txt
@@ -383,6 +383,16 @@ We can request that we get an error if versions are picked:
     Traceback (most recent call last):
     ...
     UserError: Picked: demo = 0.3
+    <BLANKLINE>
+    The `demo` egg does not have a version pin and `allow-picked-versions = false`.
+    <BLANKLINE>
+    To resolve this, add
+    <BLANKLINE>
+        demo = 0.3
+    <BLANKLINE>
+    to the [versions] section,
+    <BLANKLINE>
+    OR set `allow-picked-versions = true`.
 
     >>> zc.buildout.easy_install.allow_picked_versions(True)
     False

--- a/src/zc/buildout/tests/repeatable.txt
+++ b/src/zc/buildout/tests/repeatable.txt
@@ -209,6 +209,7 @@ versions:
       Installing recipe spam.
       Getting distribution for 'spam'.
     Error: Picked: spam = 2
+    ...
 
 We can name a version something else, if we wish, using the versions option:
 


### PR DESCRIPTION
It can be improved.

Fixes #481.