### PR TITLE
Allow to run buildout in FIPS enabled environments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Change History
 2.13.5 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Allow to run buildout in FIPS enabled environments
+  (`#570 <https://github.com/buildout/buildout/issues/570>`_)
 
 
 2.13.4 (2021-03-08)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -17,10 +17,12 @@
 from zc.buildout.rmtree import rmtree
 import zc.buildout.easy_install
 
+from functools import partial
+
 try:
-    from hashlib import md5
+    from hashlib import md5 as md5_original
 except ImportError:
-    from md5 import md5
+    from md5 import md5 as md5_original
 
 try:
     from collections.abc import MutableMapping as DictMixin
@@ -49,6 +51,12 @@ if PY3:
     text_type = str
 else:
     text_type = unicode
+
+try:
+    hashed = md5_original(b'test')
+    md5 = md5_original
+except ValueError:
+    md5 = partial(md5_original, usedforsecurity=False)
 
 
 def command(method):


### PR DESCRIPTION
In relation to https://github.com/buildout/buildout/issues/570