### PR TITLE
Support python310-315 in conditional section expressions. [2.x]

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -9,7 +9,7 @@ exclude_patterns = ["builds/**"]
 
 [[analyzers]]
 name = "python"
-enabled = false
+enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,15 @@
-# We do not want this on branch 2.x, so we disable the analyzers..
 version = 1
+
+test_patterns = [
+    "zc.recipe.egg_/src/zc/recipe/egg/tests.py",
+    "src/zc/buildout/tests/**"
+]
+
+exclude_patterns = ["builds/**"]
 
 [[analyzers]]
 name = "python"
 enabled = false
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,6 @@
+# We do not want this on branch 2.x, so we disable the analyzers..
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = false

--- a/.github/workflows/scripts-versions-2.7.cfg
+++ b/.github/workflows/scripts-versions-2.7.cfg
@@ -1,4 +1,5 @@
 [versions]
+bleach = < 4
 configparser = < 5
 cryptography = < 3.4
 importlib-resources = < 4
@@ -8,5 +9,7 @@ packaging = < 21.0
 Pygments = < 2.6
 pyparsing = < 3
 readme-renderer = < 29.0
+requests = < 2.28
 twine = < 2
+zest.releaser = < 7
 zipp = < 2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Change History
 2.13.8 (unreleased)
 ===================
 
-- Nothing changed yet.
+- Support python310-315 in conditional section expressions.
 
 
 2.13.7 (2022-03-31)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1724,7 +1724,8 @@ def _default_globals():
 
     # minor python major_python_versions as python24, python25 ... python39
     minor_python_versions = ('24', '25', '26', '27',
-                             '30', '31', '32', '33', '34', '35', '36', '37', '38', '39')
+                             '30', '31', '32', '33', '34', '35', '36', '37', '38', '39',
+                             '310', '311', '312', '313', '314', '315')
     for v in minor_python_versions:
         globals_defs['python' + v] = ''.join(major_python_versions[:2]) == v
 

--- a/src/zc/buildout/configparser.test
+++ b/src/zc/buildout/configparser.test
@@ -291,7 +291,7 @@ called by buildout::
 
   # major and minor python versions, yes even python 3.5 and 3.6 are there , prospectively
   # comment: this expression "is true" and not that long expression cannot span several lines
-  [s2: any([python2, python3, python24 , python25 , python26 , python27 , python30 , python31 , python32 , python33 , python34 , python35 , python36, python37, python38,python39]) ]
+  [s2: any([python2, python3, python24 , python25 , python26 , python27 , python30 , python31 , python32 , python33 , python34 , python35 , python36, python37, python38, python39, python310, python311, python312, python313, python314, python315]) ]
   b = 1
 
   # common python interpreter types


### PR DESCRIPTION
If you use `zc.buildout` 2.13.7 to install [Plone 6.0.0b2](https://community.plone.org/t/plone-6-0-0b2-released/15643/2?u=mauritsvanrees) you will get an error:

    NameError: name 'python310' is not defined

See [another example of the same problem](https://github.com/collective/collective.honeypot/pull/8#issuecomment-1244568342).

Easy buildout config to try, on any Python version:

```
[buildout]
parts = test

[test]
recipe = zc.recipe.egg
eggs = build

[test:python310]
recipe = zc.recipe.egg
eggs = requests
```

This PR should fix it by supporting five more Python versions. I guess this should be enough for the foreseen lifetime of buildout 2.x. :-)

I wonder if there are better ways to solve this, but for now this should do the trick.