### PR TITLE
Make compatible with pip 22.2+, restoring Requires-Python patch

### DIFF
--- a/news/613.bugfix
+++ b/news/613.bugfix
@@ -1,0 +1,3 @@
+Make compatible with pip 22.2+, restoring Requires-Python functionality there.
+Fixes `issue 613 <https://github.com/buildout/buildout/issues/613>`_.
+[maurits]

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -138,6 +138,7 @@ def patch_PackageIndex():
                     content_type=content_type,
                     encoding=charset,
                     url=base,
+                    cache_link_parsing=False,
                 )
             except TypeError:
                 try:


### PR DESCRIPTION
Fixes https://github.com/buildout/buildout/issues/613.

Note: we are patching `process_url` from `setuptools`. The existing comment says that this method was copied over from setuptools 46.1.3. I was wondering, so I checked: the method is still the same in latest setuptools.  And it is largely unchanged since setuptools 42.0.2. So for that part we should still be compatible with quite a long range of setuptools versions.

This PR also expands the warning that is printed when the patch fails. Until now it said "Requires-Python support missing." There was no indication that this was a message from buildout, so I assumed this was something from a newer setuptools or pip, and it warned about a package that did not have a `requires_python` in its `setup.py/cfg`. Now it should be clear that it is a warning from buildout itself.