### PR TITLE
Prevent running gh-actions twice for push/pull.

### DIFF
--- a/.github/workflows/centos.yml
+++ b/.github/workflows/centos.yml
@@ -1,12 +1,18 @@
 name: Centos containers
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+strategy:
       fail-fast: false
       matrix:
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]

--- a/.github/workflows/debian-sys.yml
+++ b/.github/workflows/debian-sys.yml
@@ -1,11 +1,16 @@
 name: Debian container with system Python
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,11 +1,16 @@
 name: Debian containers
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python-runners.yml
+++ b/.github/workflows/python-runners.yml
@@ -1,11 +1,16 @@
 name: Ubuntu, MacOS, Windows machines
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes issue #617.
Copied from the zopefoundation repositories.
See https://github.com/zopefoundation/meta/issues/145 and the final version with single quotes at [meta](https://github.com/zopefoundation/meta/blob/9c24f7380973de989c5132ec9f28fa71f1397f20/config/c-code/tests.yml.j2#L93).

I also added `workflow_dispatch` to allow to run these workflows manually from the Actions tab.
