### PR TITLE
Pin versions when processing buildout section

### DIFF
--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1426,7 +1426,13 @@ def _install_and_load(spec, group, entry, buildout):
             else:
                 dest = buildout_options['eggs-directory']
                 path = [buildout_options['develop-eggs-directory']]
-
+            
+            # Pin versions when processing the buildout section
+            versions_section_name = buildout['buildout'].get('versions', 'versions')
+            versions = buildout.get(versions_section_name, {})
+            zc.buildout.easy_install.allow_picked_versions(
+                bool_option(buildout['buildout'], 'allow-picked-versions')
+                )
             zc.buildout.easy_install.install(
                 [spec], dest,
                 links=buildout._links,
@@ -1434,7 +1440,8 @@ def _install_and_load(spec, group, entry, buildout):
                 path=path,
                 working_set=pkg_resources.working_set,
                 newest=buildout.newest,
-                allow_hosts=buildout._allow_hosts
+                allow_hosts=buildout._allow_hosts,
+                versions=versions,
                 )
 
         __doing__ = 'Loading %s recipe entry %s:%s.', group, spec, entry

--- a/src/zc/buildout/tests/repeatable.txt
+++ b/src/zc/buildout/tests/repeatable.txt
@@ -184,6 +184,34 @@ versions for.
     Installing foo.
     recipe v1
 
+Edge case (issue #577) where a substitution inside the buildout section
+which comes from a section with a recipe, then the versions versions
+specifications were ignored, and the latest version installed, even if
+allow-picked-versions is false.
+
+    >>> write('buildout.cfg',
+    ... '''
+    ... [buildout]
+    ... allow-picked-versions = false
+    ... #show-picked-versions = true
+    ... parts = foo
+    ... find-links = %s
+    ... test = ${foo:option}
+    ...
+    ... [versions]
+    ... spam = 1
+    ...
+    ... [foo]
+    ... recipe = spam
+    ... option = TEST
+    ... ''' % join('recipe', 'dist'))
+
+    >>> print_(system(buildout), end='') # doctest: +ELLIPSIS
+    Uninstalling foo.
+    Section `buildout` contains unused option(s): 'test'.
+    ...
+    Installing foo.
+    recipe v1
 
 You can request buildout to generate an error if it picks any
 versions:


### PR DESCRIPTION
Resolves Issue #577, where versions are not pinned when processing the buildout section, and any prerequisite sections that are processed with it.

I can also create a patch for the buildout 2.x branch, if that is actively being maintained.