### PR TITLE
Issues 176 and 629: Process extends in order

### DIFF
--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1879,25 +1879,30 @@ def _open(
             download_options, result['buildout']
         )
 
+    # Process extends to handle nested += and -=
+    eresults = []
     if extends:
         extends = extends.split()
-        eresult, user_defaults = _open(
-            base, extends.pop(0), seen, download_options, override,
-            downloaded, user_defaults
-        )
         for fname in extends:
             next_extend, user_defaults = _open(
                 base, fname, seen, download_options, override,
-                downloaded, user_defaults
-            )
-            eresult = _update(eresult, next_extend)
-        result = _update(eresult, result)
+                downloaded, user_defaults)
+            eresults.extend(next_extend)
     else:
         if user_defaults:
             result = _update(user_defaults, result)
             user_defaults = {}
+
+    eresults.append(result)
     seen.pop()
-    return result, user_defaults
+
+    if root_config_file:
+        final_result = {}
+        for eresult in eresults:
+            final_result = _update(final_result, eresult)
+        return final_result, user_defaults
+    else:
+        return eresults, user_defaults
 
 
 ignore_directories = '.svn', 'CVS', '__pycache__', '.git'

--- a/src/zc/buildout/tests/test_increment.py
+++ b/src/zc/buildout/tests/test_increment.py
@@ -390,6 +390,41 @@ def no_default_with_extends_increment_in_base2_and_base3():
     versions= versions
         DEFAULT_VALUE
     """
+def increment_buildout_with_multiple_extended_without_base_equals():
+    r"""
+    >>> write('buildout.cfg', '''
+    ... [buildout]
+    ... extends = base1.cfg base2.cfg
+    ... parts += foo
+    ... [foo]
+    ... recipe = zc.buildout:debug
+    ... [base1]
+    ... recipe = zc.buildout:debug
+    ... [base2]
+    ... recipe = zc.buildout:debug
+    ... ''')
+    >>> write('base1.cfg', '''
+    ... [buildout]
+    ... extends = base3.cfg
+    ... parts += base1
+    ... ''')
+    >>> write('base2.cfg', '''
+    ... [buildout]
+    ... extends = base3.cfg
+    ... parts += base2
+    ... ''')
+    >>> write('base3.cfg', '''
+    ... [buildout]
+    ... ''')
+
+    >>> print_(system(buildout), end='')
+    Installing base1.
+      recipe='zc.buildout:debug'
+    Installing base2.
+      recipe='zc.buildout:debug'
+    Installing foo.
+      recipe='zc.buildout:debug'
+    """
 
 def test_suite():
     return doctest.DocTestSuite(


### PR DESCRIPTION
Process extends in order, otherwise variable settings can be applied out of order.
Fixes #176
Closes #177
Fixes #629.

I first submitted this patch almost 10 years ago. We run a **very** complex buildout, and this breaks it.  I've been patching buildout 2, for almost 10 years, with no issues. The application of this patch to buildout 3 was very straightforward.  I believe this fix is stable, and would really appreciate seeing it incorporated. 

Thank you.