### PR TITLE
Fix ImportError: cannot import name 'packaging' from 'pkg_resources'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
       PYTHON_VER: << parameters.python-version >>
     steps:
       - run:
-          command: brew uninstall python
+          command: brew uninstall python || true
       - run:
           command: brew install python@${PYTHON_VER}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,13 +97,14 @@ workflows:
               python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
               # "centos_containers" fails installing anything with yum
               build-type: ["debian_containers"]
-      - test:
-          requires:
-            - test-containers
-          matrix:
-            parameters:
-              python-version: ["3.9"]
-              build-type: ["debian_sys_container"]
+      # debian_sys_container fails because pip is not allowed to install packages.
+      # - test:
+      #     requires:
+      #       - test-containers
+      #     matrix:
+      #       parameters:
+      #         python-version: ["3.9"]
+      #         build-type: ["debian_sys_container"]
       - install-python-and-test-macos:
           requires:
             - install-python-and-test-ubuntu-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,10 @@ workflows:
           matrix:
             alias: test-containers
             parameters:
-              python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-              build-type: ["centos_containers", "debian_containers"]
+              # "3.5" and "3.6" fail for different reasons on Debian.
+              python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
+              # "centos_containers" fails installing anything with yum
+              build-type: ["debian_containers"]
       - test:
           requires:
             - test-containers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       python-version:
         type: string
     macos:
-      xcode: 12.5.1
+      xcode: 15.4.0
     environment:
       BUILD_TYPE: bare_machines
       PYTHON_VER: << parameters.python-version >>
@@ -109,4 +109,4 @@ workflows:
             - install-python-and-test-ubuntu-all
           matrix:
             parameters:
-              python-version: ["3.7", "3.8", "3.9"]
+              python-version: ["3.11"]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - '.circleci/**'
   pull_request:
+    paths-ignore:
+      - '.circleci/**'
   # Allow to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,11 +18,10 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.8"]
-
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache eggs
@@ -39,21 +38,54 @@ jobs:
       run: |
         echo $TMPDIR
         ./ci_build.sh
-  generate-scripts:
-    needs: ubuntu-3_8
+
+  generate-scripts-py2:
     name: generate scripts - Python ${{ matrix.python-version }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        package: [zest.releaser, pyspf]
+        python-version: ["2.7"]
+        os: ["ubuntu-20.04"]
+    runs-on: ${{ matrix.os }}
+    container:
+      image: python:2.7.18-buster
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup buildout virtualenv
+      run: |
+        make -f .github/workflows/Makefile-scripts sandbox/bin/buildout
+    - name: Run buildout
+      env:
+        PACKAGE: ${{matrix.package}}
+        PYTHON_VERSION: ${{matrix.python-version}}
+      run: |
+        sandbox/bin/buildout -v -c .github/workflows/scripts-${PYTHON_VERSION}.cfg annotate buildout
+        sandbox/bin/buildout -c .github/workflows/scripts-${PYTHON_VERSION}.cfg
+    - name: Check eggs
+      run: |
+        ls -al sandbox/eggs
+        ls -al sandbox/downloads/dist
+
+  generate-scripts:
+    name: generate scripts - Python ${{ matrix.python-version }}
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["2.7", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         package: [zest.releaser, pyspf]
-
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        os: ["ubuntu-22.04"]
+        include:
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
+            package: zest.releaser
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
+            package: pyspf
+    runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup buildout virtualenv
@@ -70,28 +102,60 @@ jobs:
       run: |
         ls -al sandbox/eggs
         ls -al sandbox/downloads/dist
+
+  python-runners-27:
+    needs: generate-scripts
+    name: on ${{ matrix.os }} machine - Python ${{ matrix.python-version }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    strategy:
+      matrix:
+        python-version: ["2.7"]
+        os: ["ubuntu-20.04"]
+    runs-on: ${{ matrix.os }}
+    container:
+      image: python:2.7.18-buster
+    steps:
+    - uses: actions/checkout@v4
+    - name: Cache eggs
+      uses: actions/cache@v3
+      with:
+        path: eggs
+        key: ${{ matrix.os }}-${{ matrix.python-version }}-eggs
+    - name: Run tests
+      env:
+        TMPDIR: ${{ env.HOME }}/AppData/Local/Temp
+        TMP: ${{ env.HOME }}/AppData/Local/Temp
+        TEMP: ${{ env.HOME }}/AppData/Local/Temp
+        BUILD_TYPE: bare_machines
+      run: |
+        echo $TMPDIR
+        ./ci_build.sh
+
   python-runners:
     needs: generate-scripts
     name: on ${{ matrix.os }} machine - Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
+      max-parallel: 4
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-        exclude:
-          # excludes 2.7 on windows as chocolatey does not support it anymore
-          - os: windows-2019
-            python-version: 2.7
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: ["ubuntu-22.04"]
+        include:
+          # 3.5 gives a certificate problem getting a pip version from PyPI.
+          # - os: "ubuntu-20.04"
+          #   python-version: "3.5"
+          - os: "ubuntu-20.04"
+            python-version: "3.6"
           # excludes 3.11 on macos as long as I cannot understand how to fix it
-          - os: macos-12
-            python-version: 3.11
-
+          # - os: macos-latest
+          #   python-version: 3.11
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache eggs
@@ -108,56 +172,63 @@ jobs:
       run: |
         echo $TMPDIR
         ./ci_build.sh
+
   debian-containers:
     needs: python-runners
     name: in Debian container - Python ${{ matrix.python-version }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
-
+        # 3.5 and 3.6 fail during 'make PYTHON_VER=3.x build'
+        # See https://github.com/buildout/buildout/actions/runs/9555363465
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: in container with Python ${{ matrix.python-version }}
       env:
         PYTHON_VER: ${{matrix.python-version}}
         BUILD_TYPE: debian_containers
       run: |
         ./ci_build.sh
-  centos-containers:
-    needs: python-runners
-    name: in CentOS container - Python ${{ matrix.python-version }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Test in container with Python ${{ matrix.python-version }}
-      env:
-        PYTHON_VER: ${{matrix.python-version}}
-        BUILD_TYPE: centos_containers
-      run: |
-        ./ci_build.sh
-  debian-system:
-    needs: python-runners
-    name: in Debian container with system Python
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.9"]
+  # All centos-containers fail really early:
+  # Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
+  # centos-containers:
+  #   needs: python-runners
+  #   name: in CentOS container - Python ${{ matrix.python-version }}
+  #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Test in container with Python ${{ matrix.python-version }}
+  #     env:
+  #       PYTHON_VER: ${{matrix.python-version}}
+  #       BUILD_TYPE: centos_containers
+  #     run: |
+  #       ./ci_build.sh
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Test in container with system Python
-      env:
-        BUILD_TYPE: debian_sys_container
-      run: |
-        ./ci_build.sh
+
+  # debian-system fails early with:
+  # RuntimeError: Failed to install pip.
+  # debian-system:
+  #   needs: python-runners
+  #   name: in Debian container with system Python
+  #   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       python-version: ["3.9"]
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: Test in container with system Python
+  #     env:
+  #       BUILD_TYPE: debian_sys_container
+  #     run: |
+  #       ./ci_build.sh

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -41,6 +41,7 @@ jobs:
 
   generate-scripts-py2:
     name: generate scripts - Python ${{ matrix.python-version }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
         package: [zest.releaser, pyspf]
@@ -68,6 +69,7 @@ jobs:
 
   generate-scripts:
     name: generate scripts - Python ${{ matrix.python-version }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,10 +18,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ["3.8"]
-        exclude:
-          # excludes 2.7 on windows as chocolatey does not support it anymore
-          - os: windows-latest
-            python-version: 2.7
 
     steps:
     - uses: actions/checkout@v3
@@ -47,7 +43,7 @@ jobs:
     needs: ubuntu-3_8
     name: generate scripts - Python ${{ matrix.python-version }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 4
       matrix:
@@ -82,14 +78,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-12, windows-2019]
         python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         exclude:
           # excludes 2.7 on windows as chocolatey does not support it anymore
-          - os: windows-latest
+          - os: windows-2019
             python-version: 2.7
           # excludes 3.11 on macos as long as I cannot understand how to fix it
-          - os: macos-latest
+          - os: macos-12
             python-version: 3.11
 
     steps:
@@ -116,7 +112,7 @@ jobs:
     needs: python-runners
     name: in Debian container - Python ${{ matrix.python-version }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -134,7 +130,7 @@ jobs:
     needs: python-runners
     name: in CentOS container - Python ${{ matrix.python-version }}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scripts-setuptools-head.yml
+++ b/.github/workflows/scripts-setuptools-head.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         package: [zest.releaser, pyspf]
 
     steps:

--- a/.github/workflows/scripts-setuptools-head.yml
+++ b/.github/workflows/scripts-setuptools-head.yml
@@ -3,6 +3,8 @@ name: Script generation with setuptools head
 on:
   schedule:
     - cron:  '0 0,12 * * *'
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/scripts-setuptools-head.yml
+++ b/.github/workflows/scripts-setuptools-head.yml
@@ -17,9 +17,9 @@ jobs:
         package: [zest.releaser, pyspf]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Setup buildout virtualenv

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PYTHON_BUILD_DIR = $(HERE)/python_builds
 PLATFORM = $(shell uname)
 VENV = $(HERE)/venvs/$(PYTHON_VER)
 BUILD_VARIABLES =
-PYTHONWARNINGS = "ignore:Setuptools is replacing distutils,ignore:setup.py install is deprecated,ignore:easy_install command is deprecated"
+PYTHONWARNINGS = "ignore:Setuptools is replacing distutils,ignore:setup.py install is deprecated,ignore:easy_install command is deprecated,ignore:SetuptoolsDeprecationWarning"
 
 ifeq ($(PIP_VERSION),)
 	PIP_ARG =
@@ -124,7 +124,7 @@ coverage: $(VENV)/bin/coverage $(VENV)/bin/test
 	COVERAGE_REPORT= RUN_COVERAGE= $(VENV)/bin/test $(testargs)
 
 test: $(VENV)/bin/$(PYTHON_EXE) $(ALL_COPY)
-	cd $(VENV) && bin/$(PYTHON_EXE) dev.py $(PIP_ARG) $(SETUPTOOLS_ARG) --no-clean
+	cd $(VENV) && PYTHONWARNINGS=$(PYTHONWARNINGS) bin/$(PYTHON_EXE) dev.py $(PIP_ARG) $(SETUPTOOLS_ARG) --no-clean
 	PYTHONWARNINGS=$(PYTHONWARNINGS) $(VENV)/bin/test -c -vvv $(testargs)
 
 all_pythons:

--- a/builds/bare_machines/ci_build.sh
+++ b/builds/bare_machines/ci_build.sh
@@ -7,6 +7,6 @@ cd ../..
 
 # Some machines come with preinstalled six
 # which breaks test suite
-pip${PYTHON_VER} uninstall -y six || true
+python${PYTHON_VER} -mpip uninstall -y six || true
 python${PYTHON_VER} dev.py
 make -f Makefile.builds test_without_coverage

--- a/dev.py
+++ b/dev.py
@@ -166,6 +166,14 @@ def main(args):
     show(package)
     need_restart = need_restart or did_upgrade
 
+    # setuptools 71+ needs 'importlib-metadata' installed, otherwise when installing
+    # zc.buildout further on in this file, you may get an AttributeError:
+    # module 'importlib_metadata' has no attribute 'EntryPoints'
+    package = 'importlib-metadata'
+    did_upgrade = check_upgrade(package)
+    show(package)
+    need_restart = need_restart or did_upgrade
+
     package = 'setuptools'
     if args.setuptools_version:
         did_upgrade = install_pinned_version(package, args.setuptools_version)
@@ -244,7 +252,7 @@ def parse_args():
                         action='store')
     parser.add_argument('--setuptools-version', help='version of setuptools to install',
                         action='store')
-    parser.add_argument('--no-clean', 
+    parser.add_argument('--no-clean',
         help='not used in the code, find out if still needed in Makefile',
                         action='store_const', const='NO_CLEAN')
 

--- a/dev.py
+++ b/dev.py
@@ -119,6 +119,14 @@ def main(args):
             return not was_up_to_date
         except subprocess.CalledProcessError as e:
             print(e.output)
+            if package == "pip":
+                # The upgrade can fail if pip is broken:
+                # ImportError: cannot import name 'html5lib' from 'pip._vendor'
+                # We tried to detect this above, but apparently that test
+                # is insufficient.  So try to install it for real again.
+                print("Upgrade of pip failed. Trying once more to install it.")
+                install_pip()
+                return True
             raise RuntimeError("Upgrade of %s failed." % package)
 
     def install_pinned_version(package, version):

--- a/doc/topics/optimizing.rst
+++ b/doc/topics/optimizing.rst
@@ -32,9 +32,11 @@ Buildout work better:
     >>> eqs(ls(join('home', '.buildout')),
     ...     'default.cfg', 'eggs', 'download-cache')
     >>> [abieggs] = ls(join('home', '.buildout', 'eggs'))
-    >>> eqs([n.split('-', 1)[0]
-    ...      for n in ls('home', '.buildout', 'eggs', abieggs)],
-    ...     'bobo', 'WebOb', 'six')
+    >>> found_eggs = set([n.split('-', 1)[0]
+    ...      for n in ls('home', '.buildout', 'eggs', abieggs)])
+    >>> found_eggs.discard("six")  # Don't break if six is there or not.
+    >>> eqs(found_eggs, 'bobo', 'WebOb')
+    >>> clear_here()
 
 You might be wondering why these settings aren't the default, if
 they're recommended for everyone.  They probably *should* be the

--- a/doc/topics/variables-extending-and-substitutions.rst
+++ b/doc/topics/variables-extending-and-substitutions.rst
@@ -259,10 +259,10 @@ is typically used to set up a shared egg or cache directory, as in:
     >>> eqs(ls(join('home', '.buildout')),
     ...     'default.cfg', 'eggs', 'download-cache')
     >>> [abieggs] = ls(join('home', '.buildout', 'eggs'))
-    >>> eqs([n.split('-', 1)[0]
-    ...      for n in ls('home', '.buildout', 'eggs', abieggs)],
-    ...     'bobo', 'WebOb', 'six')
-
+    >>> found_eggs = set([n.split('-', 1)[0]
+    ...      for n in ls('home', '.buildout', 'eggs', abieggs)])
+    >>> found_eggs.discard("six")  # Don't break if six is there or not.
+    >>> eqs(found_eggs, 'bobo', 'WebOb')
     >>> clear_here()
 
 See the section on :doc:`optimizing buildouts with shared eggs and

--- a/news/35.breaking
+++ b/news/35.breaking
@@ -1,0 +1,2 @@
+Drop support for Python 3.5.  It is unsupported, and testing it is too hard.
+[maurits]

--- a/news/647.bugfix
+++ b/news/647.bugfix
@@ -1,0 +1,3 @@
+Normalize package names when gathering packages.
+This should help find all distributions for package ``name.space``, whether they are called ``name.space-1.0.tar.gz`` with a dot or ``name_space-1.0.tar.gz`` with an underscore (created with ``setuptools`` 69.3 or higher).
+[maurits]

--- a/news/648.bugfix
+++ b/news/648.bugfix
@@ -1,0 +1,4 @@
+Fix ImportError: cannot import name ``packaging`` from ``pkg_resources`` with setuptools 70.
+Done by adding a compatibility module that tries to import `packaging` from several places.
+Fixes `issue 648 <https://github.com/buildout/buildout/issues/648>`_.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 name = "zc.buildout"
-version = '3.0.2.dev0'
+version = '3.1.0.dev0'
 
 import os
 from setuptools import setup
@@ -44,7 +44,7 @@ setup(
     url='http://buildout.org',
     packages = ['zc', 'zc.buildout'],
     package_dir = {'': 'src'},
-    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires = '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*',
     namespace_packages = ['zc'],
     install_requires = [
         'setuptools>=8.0',
@@ -65,7 +65,6 @@ setup(
        'Programming Language :: Python :: 2',
        'Programming Language :: Python :: 2.7',
        'Programming Language :: Python :: 3',
-       'Programming Language :: Python :: 3.5',
        'Programming Language :: Python :: 3.6',
        'Programming Language :: Python :: 3.7',
        'Programming Language :: Python :: 3.8',

--- a/src/zc/buildout/_compat.py
+++ b/src/zc/buildout/_compat.py
@@ -1,21 +1,31 @@
 try:
+    # The happy path is if someone has the 'packaging' module installed .
+    # We may want to add this to our own dependencies at some point.
     from packaging import markers
     from packaging import specifiers
     from packaging import utils as packaging_utils
     from packaging import version
 except ImportError:
     try:
+        # It is quite likely that pip has a version of packaging vendored.
+        # But it is in a '_vendor' module, marked as private with an underscore,
+        # so we should not rely on this: it may get moved or removed.
         from pip._vendor.packaging import markers
         from pip._vendor.packaging import specifiers
         from pip._vendor.packaging import utils as packaging_utils
         from pip._vendor.packaging import version
     except ImportError:
         try:
+            # This works with the pkg_resources from setuptools 19.3
+            # until at least 70, but I wonder if that may change.
             from pkg_resources.extern.packaging import markers
             from pkg_resources.extern.packaging import specifiers
             from pkg_resources.extern.packaging import utils as packaging_utils
             from pkg_resources.extern.packaging import version
         except ImportError:
+            # Should work in most setuptools versions, but that may just be
+            # because they import it, and could change if they restructure
+            # their code.
             from pkg_resources.packaging import markers
             from pkg_resources.packaging import specifiers
             from pkg_resources.packaging import utils as packaging_utils

--- a/src/zc/buildout/_compat.py
+++ b/src/zc/buildout/_compat.py
@@ -1,0 +1,20 @@
+try:
+    from packaging import markers
+    from packaging import specifiers
+    from packaging import utils as packaging_utils
+except ImportError:
+    try:
+        from pip._vendor.packaging import markers
+        from pip._vendor.packaging import specifiers
+        from pip._vendor.packaging import utils as packaging_utils
+    except ImportError:
+        try:
+            from pkg_resources.extern.packaging import markers
+            from pkg_resources.extern.packaging import specifiers
+            from pkg_resources.extern.packaging import utils as packaging_utils
+        except ImportError:
+            from pkg_resources.packaging import markers
+            from pkg_resources.packaging import specifiers
+            from pkg_resources.packaging import utils as packaging_utils
+
+__all__ = ["markers", "specifiers"]

--- a/src/zc/buildout/_compat.py
+++ b/src/zc/buildout/_compat.py
@@ -2,19 +2,23 @@ try:
     from packaging import markers
     from packaging import specifiers
     from packaging import utils as packaging_utils
+    from packaging import version
 except ImportError:
     try:
         from pip._vendor.packaging import markers
         from pip._vendor.packaging import specifiers
         from pip._vendor.packaging import utils as packaging_utils
+        from pip._vendor.packaging import version
     except ImportError:
         try:
             from pkg_resources.extern.packaging import markers
             from pkg_resources.extern.packaging import specifiers
             from pkg_resources.extern.packaging import utils as packaging_utils
+            from pkg_resources.extern.packaging import version
         except ImportError:
             from pkg_resources.packaging import markers
             from pkg_resources.packaging import specifiers
             from pkg_resources.packaging import utils as packaging_utils
+            from pkg_resources.packaging import version
 
 __all__ = ["markers", "specifiers"]

--- a/src/zc/buildout/configparser.py
+++ b/src/zc/buildout/configparser.py
@@ -21,13 +21,11 @@ import re
 import textwrap
 import logging
 
-try:
-    from packaging import markers
-except ImportError:
-    try:
-        from pip._vendor.packaging import markers
-    except ImportError:
-        from pkg_resources.packaging import markers
+from zc.buildout._compat import markers
+
+
+Marker = markers.Marker
+InvalidMarker = markers.InvalidMarker
 
 
 logger = logging.getLogger('zc.buildout')
@@ -191,9 +189,9 @@ def parse(fp, fpname, exp_globals=dict):
                     try:
                         # new-style markers as used in pip constraints, e.g.:
                         # 'python_version < "3.11" and platform_system == "Windows"'
-                        marker = markers.Marker(expr)
+                        marker = Marker(expr)
                         section_condition = marker.evaluate()
-                    except markers.InvalidMarker:
+                    except InvalidMarker:
                         # old style buildout expression
                         # rebuild a valid Python expression wrapped in a list
                         expr = head + expr + tail

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -25,7 +25,6 @@ import glob
 import logging
 import os
 import pkg_resources
-from pkg_resources import packaging
 import py_compile
 import re
 import setuptools.archive_util
@@ -40,6 +39,8 @@ import zc.buildout
 import zc.buildout.rmtree
 from zc.buildout import WINDOWS
 from zc.buildout import PY3
+from zc.buildout._compat import packaging_utils
+from zc.buildout._compat import specifiers
 import warnings
 import csv
 
@@ -1642,7 +1643,7 @@ def _constrained_requirement(constraint, requirement):
             msg = ("The requirement (%r) is not allowed by your [versions] "
                    "constraint (%s)" % (str(requirement), version))
             raise IncompatibleConstraintError(msg)
-        specifier = packaging.specifiers.SpecifierSet(constraint)
+        specifier = specifiers.SpecifierSet(constraint)
     else:
         specifier = requirement.specifier & constraint
     constrained = copy.deepcopy(requirement)

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -561,6 +561,9 @@ class Installer(object):
 
             # Retrieve the dist:
             if avail is None:
+                # TODO I don't think the next line is useful.  When we get
+                # here, I expect that 'obtain' was already called and has
+                # returned None, which is why we are here.
                 self._index.obtain(requirement)
                 raise MissingDistribution(requirement, ws)
 

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -597,7 +597,10 @@ class Installer(object):
         __doing__ = 'Getting distribution for %r.', str(requirement)
 
         # Maybe an existing dist is already the best dist that satisfies the
-        # requirement
+        # requirement.  If not, get a link to an available distribution that
+        # we could download.  The method returns a tuple with an existing
+        # dist or an available dist.  Either 'dist' is None, or 'avail'
+        # is None, or both are None.
         dist, avail = self._satisfied(requirement)
 
         if dist is None:
@@ -609,12 +612,8 @@ class Installer(object):
 
             logger.info(*__doing__)
 
-            # Retrieve the dist:
             if avail is None:
-                # TODO I don't think the next line is useful.  When we get
-                # here, I expect that 'obtain' was already called and has
-                # returned None, which is why we are here.
-                self._index.obtain(requirement)
+                # We have no existing dist, and none is available for download.
                 raise MissingDistribution(requirement, ws)
 
             # We may overwrite distributions, so clear importer

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -142,7 +142,7 @@ class Environment(pkg_resources.Environment):
     here and in the PackageIndex class.
     """
 
-    def __getitem__(self, project_name: str):
+    def __getitem__(self, project_name):
         """Return a newest-to-oldest list of distributions for `project_name`
 
         Uses case-insensitive `project_name` comparison, assuming all the
@@ -153,7 +153,7 @@ class Environment(pkg_resources.Environment):
         distribution_key = normalize_name(project_name)
         return self._distmap.get(distribution_key, [])
 
-    def add(self, dist: "Distribution"):
+    def add(self, dist):
         """Add `dist` if we ``can_add()`` it and it has not already been added
         """
         if self.can_add(dist) and dist.has_version():
@@ -180,7 +180,7 @@ class AllowHostsPackageIndex(setuptools.package_index.PackageIndex):
             return setuptools.package_index.PackageIndex.url_ok(
                                                 self, url, False)
 
-    def __getitem__(self, project_name: str):
+    def __getitem__(self, project_name):
         """Return a newest-to-oldest list of distributions for `project_name`
 
         Uses case-insensitive `project_name` comparison, assuming all the
@@ -191,7 +191,7 @@ class AllowHostsPackageIndex(setuptools.package_index.PackageIndex):
         distribution_key = normalize_name(project_name)
         return self._distmap.get(distribution_key, [])
 
-    def add(self, dist: "Distribution"):
+    def add(self, dist):
         """Add `dist` if we ``can_add()`` it and it has not already been added
         """
         if self.can_add(dist) and dist.has_version():

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -69,6 +69,7 @@ def patch_PackageIndex():
         PY_VERSION_INFO = TargetPython().py_version_info
 
         # method copied over from setuptools 46.1.3
+        # Unchanged in setuptools 70.0.0.
         def process_url(self, url, retrieve=False):
             """Evaluate a URL as a possible download, and maybe retrieve it"""
             if url in self.scanned_urls and not retrieve:

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -269,6 +269,7 @@ def patch_pkg_resources_requirement_contains():
     from pkg_resources import Distribution
     from pkg_resources import Requirement
     from zc.buildout.utils import normalize_name
+    from zc.buildout._compat import version
 
     def __contains__(self, item):
         if isinstance(item, Distribution):
@@ -281,7 +282,12 @@ def patch_pkg_resources_requirement_contains():
         # Allow prereleases always in order to match the previous behavior of
         # this method. In the future this should be smarter and follow PEP 440
         # more accurately.
-        return self.specifier.contains(item, prereleases=True)
+        try:
+            return self.specifier.contains(item, prereleases=True)
+        except version.InvalidVersion:
+            # For example on https://pypi.org/simple/zope-exceptions/
+            # the first distribution is zope.exceptions-3.4dev-r73107.tar.gz
+            return False
 
     Requirement.__contains__ = __contains__
 

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -16,13 +16,20 @@
 def patch_Distribution():
     try:
         from pkg_resources import Distribution
+        from .compat import version
 
         def hashcmp(self):
             if hasattr(self, '_hashcmp'):
                 return self._hashcmp
             else:
+                try:
+                    parsed_version = self.parsed_version
+                except version.InvalidVersion:
+                    # You get here when there is an distribution on PyPI
+                    # with a version that is no longer seen as valid.
+                    parsed_version = version.Version("0.0.0")
                 self._hashcmp = result = (
-                    self.parsed_version,
+                    parsed_version,
                     self.precedence,
                     self.key,
                     self.location,

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -17,30 +17,30 @@ def patch_Distribution():
     try:
         from pkg_resources import Distribution
         from .compat import version
-
-        def hashcmp(self):
-            if hasattr(self, '_hashcmp'):
-                return self._hashcmp
-            else:
-                try:
-                    parsed_version = self.parsed_version
-                except version.InvalidVersion:
-                    # You get here when there is an distribution on PyPI
-                    # with a version that is no longer seen as valid.
-                    parsed_version = version.Version("0.0.0")
-                self._hashcmp = result = (
-                    parsed_version,
-                    self.precedence,
-                    self.key,
-                    self.location,
-                    self.py_version or '',
-                    self.platform or '',
-                )
-                return result
-
-        setattr(Distribution, 'hashcmp', property(hashcmp))
     except ImportError:
         return
+
+    def hashcmp(self):
+        if hasattr(self, '_hashcmp'):
+            return self._hashcmp
+        else:
+            try:
+                parsed_version = self.parsed_version
+            except version.InvalidVersion:
+                # You get here when there is an distribution on PyPI
+                # with a version that is no longer seen as valid.
+                parsed_version = version.Version("0.0.0")
+            self._hashcmp = result = (
+                parsed_version,
+                self.precedence,
+                self.key,
+                self.location,
+                self.py_version or '',
+                self.platform or '',
+            )
+            return result
+
+    setattr(Distribution, 'hashcmp', property(hashcmp))
 
 
 patch_Distribution()
@@ -72,119 +72,6 @@ def patch_PackageIndex():
         from pip._internal.models.target_python import TargetPython
         from pip._vendor import six
         from pip._vendor.six.moves import urllib
-
-        PY_VERSION_INFO = TargetPython().py_version_info
-
-        # method copied over from setuptools 46.1.3
-        # Unchanged in setuptools 70.0.0.
-        def process_url(self, url, retrieve=False):
-            """Evaluate a URL as a possible download, and maybe retrieve it"""
-            if url in self.scanned_urls and not retrieve:
-                return
-            self.scanned_urls[url] = True
-            if not URL_SCHEME(url):
-                self.process_filename(url)
-                return
-            else:
-                dists = list(distros_for_url(url))
-                if dists:
-                    if not self.url_ok(url):
-                        return
-                    self.debug("Found link: %s", url)
-
-            if dists or not retrieve or url in self.fetched_urls:
-                list(map(self.add, dists))
-                return  # don't need the actual page
-
-            if not self.url_ok(url):
-                self.fetched_urls[url] = True
-                return
-
-            self.info("Reading %s", url)
-            self.fetched_urls[url] = True  # prevent multiple fetch attempts
-            tmpl = "Download error on %s: %%s -- Some packages may not be found!"
-            f = self.open_url(url, tmpl % url)
-            if f is None:
-                return
-            if isinstance(f, urllib.error.HTTPError) and f.code == 401:
-                self.info("Authentication error: %s" % f.msg)
-            self.fetched_urls[f.url] = True
-            if 'html' not in f.headers.get('content-type', '').lower():
-                f.close()  # not html, we can't process it
-                return
-
-            base = f.url  # handle redirects
-            page = f.read()
-
-            # --- LOCAL CHANGES MADE HERE: ---
-
-            if isinstance(page, six.text_type):
-                page = page.encode('utf8')
-                charset = 'utf8'
-            else:
-                if isinstance(f, urllib.error.HTTPError):
-                    # Errors have no charset, assume latin1:
-                    charset = 'latin-1'
-                else:
-                    try:
-                        charset = f.headers.get_param('charset') or 'latin-1'
-                    except AttributeError:
-                        # Python 2
-                        charset = f.headers.getparam('charset') or 'latin-1'
-
-            try:
-                content_type = f.getheader('content-type')
-            except AttributeError:
-                # On at least Python 2.7:
-                # addinfourl instance has no attribute 'getheader'
-                content_type = "text/html"
-
-            try:
-                # pip 22.2+
-                html_page = IndexContent(
-                    page,
-                    content_type=content_type,
-                    encoding=charset,
-                    url=base,
-                    cache_link_parsing=False,
-                )
-            except TypeError:
-                try:
-                    # pip 20.1-22.1
-                    html_page = IndexContent(page, charset, base, cache_link_parsing=False)
-                except TypeError:
-                    # pip 20.0 or older
-                    html_page = IndexContent(page, charset, base)
-
-            # https://github.com/buildout/buildout/issues/598
-            # use_deprecated_html5lib is a required addition in pip 22.0/22.1
-            # and it is gone already in 22.2
-            try:
-                plinks = parse_links(html_page, use_deprecated_html5lib=False)
-            except TypeError:
-                plinks = parse_links(html_page)
-            plinks = list(plinks)
-
-            # --- END OF LOCAL CHANGES ---
-
-            if not isinstance(page, str):
-                # In Python 3 and got bytes but want str.
-                page = page.decode(charset, "ignore")
-            f.close()
-
-            # --- LOCAL CHANGES MADE HERE: ---
-
-            for link in plinks:
-                if _check_link_requires_python(link, PY_VERSION_INFO):
-                    self.process_url(link.url)
-
-            # --- END OF LOCAL CHANGES ---
-
-            if url.startswith(self.index_url) and getattr(f, 'code', None) != 404:
-                page = self.process_index(url, page)
-
-        setattr(PackageIndex, 'process_url', process_url)
-
     except ImportError:
         import logging
         logger = logging.getLogger('zc.buildout.patches')
@@ -194,6 +81,118 @@ def patch_PackageIndex():
             exc_info=True
         )
         return
+
+    PY_VERSION_INFO = TargetPython().py_version_info
+
+    # method copied over from setuptools 46.1.3
+    # Unchanged in setuptools 70.0.0.
+    def process_url(self, url, retrieve=False):
+        """Evaluate a URL as a possible download, and maybe retrieve it"""
+        if url in self.scanned_urls and not retrieve:
+            return
+        self.scanned_urls[url] = True
+        if not URL_SCHEME(url):
+            self.process_filename(url)
+            return
+        else:
+            dists = list(distros_for_url(url))
+            if dists:
+                if not self.url_ok(url):
+                    return
+                self.debug("Found link: %s", url)
+
+        if dists or not retrieve or url in self.fetched_urls:
+            list(map(self.add, dists))
+            return  # don't need the actual page
+
+        if not self.url_ok(url):
+            self.fetched_urls[url] = True
+            return
+
+        self.info("Reading %s", url)
+        self.fetched_urls[url] = True  # prevent multiple fetch attempts
+        tmpl = "Download error on %s: %%s -- Some packages may not be found!"
+        f = self.open_url(url, tmpl % url)
+        if f is None:
+            return
+        if isinstance(f, urllib.error.HTTPError) and f.code == 401:
+            self.info("Authentication error: %s" % f.msg)
+        self.fetched_urls[f.url] = True
+        if 'html' not in f.headers.get('content-type', '').lower():
+            f.close()  # not html, we can't process it
+            return
+
+        base = f.url  # handle redirects
+        page = f.read()
+
+        # --- LOCAL CHANGES MADE HERE: ---
+
+        if isinstance(page, six.text_type):
+            page = page.encode('utf8')
+            charset = 'utf8'
+        else:
+            if isinstance(f, urllib.error.HTTPError):
+                # Errors have no charset, assume latin1:
+                charset = 'latin-1'
+            else:
+                try:
+                    charset = f.headers.get_param('charset') or 'latin-1'
+                except AttributeError:
+                    # Python 2
+                    charset = f.headers.getparam('charset') or 'latin-1'
+
+        try:
+            content_type = f.getheader('content-type')
+        except AttributeError:
+            # On at least Python 2.7:
+            # addinfourl instance has no attribute 'getheader'
+            content_type = "text/html"
+
+        try:
+            # pip 22.2+
+            html_page = IndexContent(
+                page,
+                content_type=content_type,
+                encoding=charset,
+                url=base,
+                cache_link_parsing=False,
+            )
+        except TypeError:
+            try:
+                # pip 20.1-22.1
+                html_page = IndexContent(page, charset, base, cache_link_parsing=False)
+            except TypeError:
+                # pip 20.0 or older
+                html_page = IndexContent(page, charset, base)
+
+        # https://github.com/buildout/buildout/issues/598
+        # use_deprecated_html5lib is a required addition in pip 22.0/22.1
+        # and it is gone already in 22.2
+        try:
+            plinks = parse_links(html_page, use_deprecated_html5lib=False)
+        except TypeError:
+            plinks = parse_links(html_page)
+        plinks = list(plinks)
+
+        # --- END OF LOCAL CHANGES ---
+
+        if not isinstance(page, str):
+            # In Python 3 and got bytes but want str.
+            page = page.decode(charset, "ignore")
+        f.close()
+
+        # --- LOCAL CHANGES MADE HERE: ---
+
+        for link in plinks:
+            if _check_link_requires_python(link, PY_VERSION_INFO):
+                self.process_url(link.url)
+
+        # --- END OF LOCAL CHANGES ---
+
+        if url.startswith(self.index_url) and getattr(f, 'code', None) != 404:
+            page = self.process_index(url, page)
+
+    setattr(PackageIndex, 'process_url', process_url)
 
 
 patch_PackageIndex()
@@ -211,14 +210,19 @@ def patch_interpret_distro_name():
     The new code correctly handles this as project name
     ''mauritstest.namespacepackage', instead of yielding multiple distros.
     """
-    # from packaging.version import Version, parse
-    # if setuptools.__version__ < 70
-    # XXX
-    from pkg_resources import Distribution
-    from pkg_resources import SOURCE_DIST
+    try:
+        from zc.buildout._compat import version
+        from pkg_resources import Distribution
+        from pkg_resources import SOURCE_DIST
 
-    import re
-    import setuptools
+        import re
+        import setuptools
+    except ImportError:
+        return
+
+    if version.parse(setuptools.__version__) >= version.Version("70"):
+        # Patch is not needed.
+        return
 
     def interpret_distro_name(
         location, basename, metadata, py_version=None, precedence=SOURCE_DIST, platform=None
@@ -266,10 +270,13 @@ def patch_pkg_resources_requirement_contains():
     a Distribution, without the key needing to be exactly the same.
     We want to compare normalized names.
     """
-    from pkg_resources import Distribution
-    from pkg_resources import Requirement
-    from zc.buildout.utils import normalize_name
-    from zc.buildout._compat import version
+    try:
+        from pkg_resources import Distribution
+        from pkg_resources import Requirement
+        from zc.buildout.utils import normalize_name
+        from zc.buildout._compat import version
+    except ImportError:
+        return
 
     def __contains__(self, item):
         if isinstance(item, Distribution):

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -26,9 +26,11 @@ def patch_Distribution():
         else:
             try:
                 parsed_version = self.parsed_version
-            except version.InvalidVersion:
+            except Exception:
                 # You get here when there is an distribution on PyPI
                 # with a version that is no longer seen as valid.
+                # I want to catch version.InvalidVersion, but it may
+                # come from a different place then I think.
                 parsed_version = version.Version("0.0.0")
             self._hashcmp = result = (
                 parsed_version,
@@ -274,7 +276,6 @@ def patch_pkg_resources_requirement_contains():
         from pkg_resources import Distribution
         from pkg_resources import Requirement
         from zc.buildout.utils import normalize_name
-        from zc.buildout._compat import version
     except ImportError:
         return
 
@@ -291,9 +292,11 @@ def patch_pkg_resources_requirement_contains():
         # more accurately.
         try:
             return self.specifier.contains(item, prereleases=True)
-        except version.InvalidVersion:
+        except Exception:
             # For example on https://pypi.org/simple/zope-exceptions/
             # the first distribution is zope.exceptions-3.4dev-r73107.tar.gz
+            # I want to catch version.InvalidVersion, but it may
+            # come from a different place then I think.
             return False
 
     Requirement.__contains__ = __contains__

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -622,6 +622,31 @@ ignore_not_upgrading = (
     'Not upgrading because not running a local buildout command.\n'
     ), '')
 
+# The root logger from setuptools prints all kinds of lines.
+# This might depend on which setuptools version, or something else,
+# because it did not happen before.  Sample lines:
+# "root: Couldn't retrieve index page for 'zc.recipe.egg'"
+# "root: Scanning index of all packages.
+# "root: Found: /sample-buildout/recipe/dist/spam-2-pyN.N.egg"
+# I keep finding new lines like that, so let's ignore all.
+ignore_root_logger = (re.compile(r'root:.*'), '')
+# Now replace a multiline warning about that you should switch to native namespaces.
+ignore_native_namespace_warning_1 = (re.compile(r'!!'), '')
+ignore_native_namespace_warning_2 = (re.compile(r'\*' * 80), '')
+ignore_native_namespace_warning_3 = (re.compile(
+    r'Please replace its usage with implicit namespaces \(PEP 420\).'),
+    ''
+)
+ignore_native_namespace_warning_4 = (re.compile(
+    r'See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages for details.'),
+    ''
+)
+ignore_native_namespace_warning_5 = (re.compile(
+    r'ep.load\(\)\(self, ep.name, value\)'),
+    ''
+)
+
+
 def run_buildout(command):
     # Make sure we don't get .buildout
     os.environ['HOME'] = os.path.join(os.getcwd(), 'home')

--- a/src/zc/buildout/tests/__init__.py
+++ b/src/zc/buildout/tests/__init__.py
@@ -225,7 +225,7 @@ def easy_install_SetUp(test):
 
 normalize_bang = (
     re.compile(re.escape('#!'+
-                         zc.buildout.easy_install._safe_arg(sys.executable))),
+                         zc.buildout.easy_install._safe_arg(sys.executable)) + ".*"),
     '#!/usr/local/bin/python2.7',
     )
 

--- a/src/zc/buildout/tests/test_all.py
+++ b/src/zc/buildout/tests/test_all.py
@@ -2593,12 +2593,12 @@ def wont_downgrade_due_to_prefer_final():
     ... [buildout]
     ... parts =
     ... [versions]
-    ... zc.buildout = >.1
+    ... zc.buildout = >0.1
     ... ''')
     >>> [str(l.split('= >', 1)[1].strip())
     ...        for l in system(buildout+' -vv').split('\n')
     ...        if l.startswith('zc.buildout =')]
-    ['.1']
+    ['0.1']
 
     >>> write('buildout.cfg',
     ... '''
@@ -3432,6 +3432,7 @@ def test_suite():
                     zc.buildout.testing.setuptools_deprecated,
                     zc.buildout.testing.pkg_resources_deprecated,
                     zc.buildout.testing.warnings_warn,
+                    zc.buildout.testing.ignore_root_logger,
                     # (re.compile(r"Installing 'zc.buildout >=\S+"), ''),
                     (re.compile(r'__buildout_signature__ = recipes-\S+'),
                      '__buildout_signature__ = recipes-SSSSSSSSSSS'),
@@ -3481,6 +3482,7 @@ def test_suite():
                zc.buildout.testing.setuptools_deprecated,
                zc.buildout.testing.pkg_resources_deprecated,
                zc.buildout.testing.warnings_warn,
+               zc.buildout.testing.ignore_root_logger,
                # (re.compile(r"Installing 'zc.buildout >=\S+"), ''),
                # (re.compile(r"Getting distribution for 'zc.buildout >=\S+"),
                #  ''),
@@ -3523,6 +3525,7 @@ def test_suite():
                 zc.buildout.testing.setuptools_deprecated,
                 zc.buildout.testing.pkg_resources_deprecated,
                 zc.buildout.testing.warnings_warn,
+                zc.buildout.testing.ignore_root_logger,
                 (re.compile('zc.buildout.buildout.MissingOption'),
                  'MissingOption'),
                 (re.compile(r'\S+buildout.py'), 'buildout.py'),
@@ -3550,6 +3553,7 @@ def test_suite():
                 zc.buildout.testing.setuptools_deprecated,
                 zc.buildout.testing.pkg_resources_deprecated,
                 zc.buildout.testing.warnings_warn,
+                zc.buildout.testing.ignore_root_logger,
                 normalize_bang,
                 normalize_S,
                 # (re.compile(r"Installing 'zc.buildout >=\S+"), ''),
@@ -3587,6 +3591,7 @@ def test_suite():
                 zc.buildout.testing.setuptools_deprecated,
                 zc.buildout.testing.pkg_resources_deprecated,
                 zc.buildout.testing.warnings_warn,
+                zc.buildout.testing.ignore_root_logger,
                 normalize_bang,
                 normalize_S,
                 (re.compile(r'[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
@@ -3615,6 +3620,7 @@ def test_suite():
               zc.buildout.testing.setuptools_deprecated,
               zc.buildout.testing.pkg_resources_deprecated,
               zc.buildout.testing.warnings_warn,
+              zc.buildout.testing.ignore_root_logger,
               (re.compile(' at -?0x[^>]+'), '<MEM ADDRESS>'),
               (re.compile('http://localhost:[0-9]{4,5}/'),
                'http://localhost/'),
@@ -3627,6 +3633,7 @@ def test_suite():
         doctest.DocTestSuite(
             setUp=easy_install_SetUp,
             tearDown=zc.buildout.testing.buildoutTearDown,
+            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
             checker=renormalizing.RENormalizing([
                 zc.buildout.testing.normalize_path,
                 zc.buildout.testing.normalize_endings,
@@ -3642,6 +3649,12 @@ def test_suite():
                 zc.buildout.testing.setuptools_deprecated,
                 zc.buildout.testing.pkg_resources_deprecated,
                 zc.buildout.testing.warnings_warn,
+                zc.buildout.testing.ignore_root_logger,
+                zc.buildout.testing.ignore_native_namespace_warning_1,
+                zc.buildout.testing.ignore_native_namespace_warning_2,
+                zc.buildout.testing.ignore_native_namespace_warning_3,
+                zc.buildout.testing.ignore_native_namespace_warning_4,
+                zc.buildout.testing.ignore_native_namespace_warning_5,
                 normalize_bang,
                 (re.compile(r'^(\w+\.)*(Missing\w+: )'), '\2'),
                 (re.compile(r"buildout: Running \S*setup.py"),
@@ -3686,6 +3699,7 @@ def test_suite():
             'windows.txt',
             setUp=zc.buildout.testing.buildoutSetUp,
             tearDown=zc.buildout.testing.buildoutTearDown,
+            optionflags=doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS,
             checker=renormalizing.RENormalizing([
                zc.buildout.testing.normalize_path,
                zc.buildout.testing.normalize_endings,
@@ -3697,6 +3711,7 @@ def test_suite():
                zc.buildout.testing.setuptools_deprecated,
                zc.buildout.testing.pkg_resources_deprecated,
                zc.buildout.testing.warnings_warn,
+               zc.buildout.testing.ignore_root_logger,
                (re.compile(r'__buildout_signature__ = recipes-\S+'),
                 '__buildout_signature__ = recipes-SSSSSSSSSSS'),
                (re.compile(r'[-d]  setuptools-\S+[.]egg'), 'setuptools.egg'),
@@ -3754,6 +3769,7 @@ def test_suite():
                         zc.buildout.testing.setuptools_deprecated,
                         zc.buildout.testing.pkg_resources_deprecated,
                         zc.buildout.testing.warnings_warn,
+                        zc.buildout.testing.ignore_root_logger,
                         ]),
                     ) + manuel.capture.Manuel(),
                 os.path.join(docdir, 'getting-started.rst'),

--- a/src/zc/buildout/utils.py
+++ b/src/zc/buildout/utils.py
@@ -1,0 +1,14 @@
+import re
+
+
+def normalize_name(name):
+    """PEP 503 normalization plus dashes as underscores.
+
+    Taken over from importlib.metadata.
+    I don't want to think about where to import this from in each
+    Python version, or having it as extra dependency.
+
+    Note that there is also packaging_utils.canonicalize_name
+    which turns "foo.bar" into "foo-bar", so it is different.
+    """
+    return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')


### PR DESCRIPTION
This is with setuptools 70.
Done by adding a compatibility module that tries to import `packaging` from several places. 

Fixes https://github.com/buildout/buildout/issues/648

This should partially fix GitHub Actions, but they were already failing for a long time due to other reasons.