### PR TITLE
Updated Patches for Issues 641 and 656

### DIFF
--- a/src/zc/buildout/configparser.py
+++ b/src/zc/buildout/configparser.py
@@ -231,7 +231,27 @@ def parse(fp, fpname, exp_globals=dict):
                     optname, optval = mo.group('name', 'value')
                     optname = optname.rstrip()
                     optval = optval.strip()
-                    cursect[optname] = optval
+                    # Handle multiple extensions of the same value in the
+                    # same file. This happens with conditional sections.
+                    opt_op = optname[-1]
+                    if opt_op not in '+-':
+                        opt_op = '='
+                    if optname in cursect and opt_op in '+-':
+                        # Strip any trailing \n, which happens when we have multiple
+                        # +=/-= in one file
+                        cursect[optname] = cursect[optname].rstrip()
+                        if optval:
+                            cursect[optname] = "%s\n%s" % (cursect[optname], optval)
+                    else:
+                        # If an assignment (=) comes after an extend (+=) /
+                        # remove (-=), it overrides and replaces the preceding
+                        # extend / remove
+                        if opt_op == '=':
+                            for suffix in '+-':
+                                tempname = "%s %s" % (optname, suffix)
+                                if tempname in cursect:
+                                    del cursect[tempname]
+                        cursect[optname] = optval
                     blockmode = not optval
                 elif not (optname or line.strip()):
                     # blank line after section start

--- a/src/zc/buildout/tests/buildout.txt
+++ b/src/zc/buildout/tests/buildout.txt
@@ -1530,6 +1530,14 @@ This is illustrated below; first we define a base configuration::
     ...     d3
     ...     d5
     ...
+    ... # Issue #641 - Properly handle options which are initially defined
+    ... # using += / -=
+    ... [part6]
+    ... option += e1
+    ...
+    ... [part7]
+    ... option -= f1
+    ...
     ... """)
 
 Extending this configuration, we can "adjust" the values set in the
@@ -1590,7 +1598,7 @@ extension that prints out the options::
     ... import sys
     ... def ext(buildout):
     ...     sys.stdout.write(str(
-    ...         [part['option'] for name, part in sorted(buildout.items())
+    ...         [part.get('option') for name, part in sorted(buildout.items())
     ...          if name.startswith('part')])+'\\n')
     ... """)
 
@@ -1629,7 +1637,7 @@ Verify option values::
     ... """)
 
     >>> print_(system(os.path.join('bin', 'buildout')), end='')
-    ['a1 a2/na3 a4/na5', 'b1 b2 b3 b4', 'c1 c2/nc3 c4 c5', 'd2/nd3/nd1/nd4', 'h1 h2']
+    ['a1 a2/na3 a4/na5', 'b1 b2 b3 b4', 'c1 c2/nc3 c4 c5', 'd2/nd3/nd1/nd4', 'h1 h2', 'e1', '']
     Develop: '/sample-buildout/demo'
 
 Annotated sections output shows which files are responsible for which
@@ -1682,6 +1690,16 @@ operations::
     [part5]
     option= h1 h2
         extension1.cfg
+    <BLANKLINE>
+    [part6]
+    option= e1
+        base.cfg
+    <BLANKLINE>
+    [part7]
+    option=
+        base.cfg
+    -=  IMPLICIT_VALUE
+    <BLANKLINE>
     [versions]
     zc.buildout= >=1.99
         DEFAULT_VALUE
@@ -1758,7 +1776,69 @@ With more verbosity::
        IN extension1.cfg
        SET VALUE = h1 h2
     <BLANKLINE>
+    [part6]
+    option= e1
+    <BLANKLINE>
+       IN base.cfg
+       SET VALUE = e1
+    <BLANKLINE>
+    <BLANKLINE>
+    [part7]
+    option=
+    <BLANKLINE>
+       IN IMPLICIT_VALUE
+       REMOVE VALUE = f1
+       IN base.cfg
+       SET VALUE = f1
+    <BLANKLINE>
+    <BLANKLINE>
+    <BLANKLINE>
     ...
+
+Issue #656 - If an option was defined in one file, then extended twice in
+another - once in a regular section and again in a conditonal, the original
+definition is lost, not extended::
+
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... extends =
+    ...     extension1.cfg
+    ...     extension2.cfg
+    ... develop = demo
+    ... extensions = demo
+    ... parts = part1
+    ... """)
+
+    >>> write(sample_buildout, 'extension1.cfg',
+    ... """
+    ... [part1]
+    ... recipe =
+    ... option =
+    ...     a
+    ...     b
+    ... """)
+
+    >>> write(sample_buildout, 'extension2.cfg',
+    ... """
+    ... [part1]
+    ... option +=
+    ...     c
+    ...     d
+    ...
+    ... [part1:False]
+    ... option +=
+    ...     z
+    ...
+    ... [part1:True]
+    ... option +=
+    ...     e
+    ... """)
+
+        ... parts = part1
+    >>> print_(system(os.path.join('bin', 'buildout')), end='')
+    ['a/nb/nc/nd/ne']
+    Develop: '/sample-buildout/demo'
 
 Cleanup::
 

--- a/src/zc/buildout/tests/configparser.test
+++ b/src/zc/buildout/tests/configparser.test
@@ -396,3 +396,123 @@ The old and new style conditional expressions can be used in the same file::
 
     >>> pprint(parse(text, zc.buildout.buildout._default_globals))
     {'section': {'a': '4', 'b': '5'}}
+
+
+Issue 656: Because conditional sections mean we can have the same
+definition twice or more in a file, the parser needs to process them in the
+order they occur in the file, and handle conflicts appropriately. For
+example, a "+=" in a non-conditional section shouldn't be overwritten by
+a "+=" in a following conditional section. Instead the second "+=" should be
+appended to the first. Likewise, an "+=" in a section *should* be overwritten
+by an "=" in a following conditional section::
+
+  [section]
+  # =, +=
+  a =
+    a
+    b
+    c
+
+  # =, -=
+  b =
+    a
+    b
+    c
+
+  # =, =
+  c =
+    a
+    b
+    c
+
+  # +=, =
+  d +=
+    a
+    b
+    c
+
+  # +=, +=
+  e +=
+    a
+    b
+    c
+
+  # +=, -=
+  f +=
+    a
+    b
+    c
+
+  # -=, =
+  g -=
+    a
+    b
+    c
+
+  # -=, +=
+  h -=
+    a
+    b
+    c
+
+  # -=, -=
+  i -=
+    a
+    b
+    c
+
+  [section:True]
+  a +=
+    d
+
+  b -=
+    b
+
+  c =
+    x
+    y
+    z
+
+  d =
+    x
+    y
+    z
+
+  e +=
+    d
+    e
+    f
+
+  f -=
+    a
+
+  g =
+    d
+    e
+    f
+
+  h +=
+    d
+    e
+    f
+
+  i -=
+    d
+
+.. -> text
+
+    >>> pprint(parse(text))
+    {'section': {'a': 'a\nb\nc',
+                 'a +': 'd',
+                 'b': 'a\nb\nc',
+                 'b -': 'b',
+                 'c': 'x\ny\nz',
+                 'd': 'x\ny\nz',
+                 'e +': 'a\nb\nc\nd\ne\nf',
+                 'f +': 'a\nb\nc',
+                 'f -': 'a',
+                 'g': 'd\ne\nf',
+                 'h +': 'd\ne\nf',
+                 'h -': 'a\nb\nc',
+                 'i -': 'a\nb\nc\nd'}}
+


### PR DESCRIPTION
Issue #656 : My earlier patch did not take into account all the various combinations of operators that could occur in multiple sections. This one does, and handles all of them properly. It also calls _update_section to ensure that any +=/-= operators are applied properly. 

The problem in Issue #641 needs to be dealt with for conditional sections, and occurs in the same place as the _update_section patch for 656, so it is included here.

I've also applied these changes to the latest buildout master branch. Tests have been updated, and are all passing under both Python 2.7 and 3.9 on my system.