### PR TITLE
Nuke trailing white space.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -169,7 +169,7 @@ Bug fixes:
 
 
 - Fix support of ``pip>=21.1`` (#567)
-- Fix confusion when using multiple Python versions and 
+- Fix confusion when using multiple Python versions and
   installing packages with C extensions
   without proper binary wheel available. (#574)
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -187,9 +187,9 @@ When you query the ``buildout`` section, you can pass the key only. For instance
 .. code-block:: console
 
    buildout query parts
-   
+
 is equivalent to the command above.
-   
+
 setup PATH SETUP-COMMANDS
 _________________________
 

--- a/old-tutorial/tutorial.fr.txt
+++ b/old-tutorial/tutorial.fr.txt
@@ -62,7 +62,7 @@ Basé sur Python
 
 - make est un langage de script horrible
 
-  - utilise le shell 
+  - utilise le shell
 
   - non portable
 
@@ -111,7 +111,7 @@ Travailler avec des eggs
     - Vérifie toujours par défaut la version la plus récente
 
       .. class:: handout
-      
+
          Lors d'une passage à une version supérieure, ``easy_install`` ne met pas à jour
          les dépendances
 
@@ -133,7 +133,7 @@ Travailler avec des eggs
      développement et utilisera ainsi cet egg en développement plutôt que l'egg
      normal.
 
-     (``easy_install`` utilise plutôt les eggs publiés ayant la même version.) 
+     (``easy_install`` utilise plutôt les eggs publiés ayant la même version.)
 
      Lorsque j'ai fini mes changements, je crée une nouvelle publication de l'egg et j'indique
      à buildout de ne plus utiliser l'egg en développement.
@@ -156,7 +156,7 @@ Travailler avec des eggs
      Nos buildouts initiaux utilisaient make.  Ils étaient difficile à maintenir et
      à réutiliser.
 
-     Il y a deux ans, nous avons créé un prototype de buildout basé sur python. 
+     Il y a deux ans, nous avons créé un prototype de buildout basé sur python.
 
      ``zc.buildout`` n'est plus un prototype et est issu de l'expérience acquise
      en utilisant le prototype.
@@ -220,7 +220,7 @@ Jargon des Eggs
      Les eggs dépendants de la plateforme contiennent des modules d'extension construits,
      ils sont donc liés à un système d'exploitation en particulier.  En outre, ils peuvent
      dépendre d'options de construction qui ne sont pas reflétées dans le nom de l'egg.
-  
+
 - Liens d'eggs en développement
 
   .. class:: handout
@@ -228,7 +228,7 @@ Jargon des Eggs
      Les liens d'eggs en développement (ou eggs en développement) sont des fichiers spéciaux
      qui permettent à un répertoire source d'être traité comme un egg. Un lien d'egg
      en développement est un fichier contenant le chemin d'un répertoire de sources.
-  
+
 - Exigences (Requirements)
 
   .. class:: handout
@@ -284,7 +284,7 @@ Points d'entrée
     .. class:: handout
 
        Buildout permet plus de contrôle sur la génération de script.
-       Le code d'initialisation et les arguments des points d'entrée peuvent être précisés. 
+       Le code d'initialisation et les arguments des points d'entrée peuvent être précisés.
 
 
 Survol de Buildout
@@ -306,16 +306,16 @@ Survol de Buildout
 
     .. class:: handout
 
-       Cela-dit, il est possible et courant de factoriser ceci dans des fichiers multiples. 
+       Cela-dit, il est possible et courant de factoriser ceci dans des fichiers multiples.
 
 - spécifie un ensemble de ``parts``
 
   - une recette (« recipe »)
- 
+
   - données de configuration
 
   .. class:: handout
-  
+
      Chaque part est définie par une recette (« recipe »), qui est un programme Python
      permettant d'installer ou de désinstaller la part, ainsi que des données utilisées
      par la recette.
@@ -327,7 +327,7 @@ Survol de Buildout
      Si une part est retirée d'une spécification, elle est désinstallée.
 
      Si la recette ou la configuration d'une part est modifiée, elle est désinstallée et réinstallée.
-     
+
 
 survol de Buildout (suite)
 ==========================
@@ -385,7 +385,7 @@ Fichiers du projet ``zope.event``
 
      On place par convention un fichier README.txt à la racine du projet.
      distutils a l'habitude de se plaindre s'il n'est pas disponible.
-  
+
 - ``bootstrap.py`` pour amorcer le buildout
 
   .. class:: handout
@@ -399,7 +399,7 @@ buildout.cfg pour zope.event
 ============================
 
 ::
-  
+
   [buildout]
   parts = test
   develop = .
@@ -425,7 +425,7 @@ buildout.cfg pour zope.event
      parts = test
 
    Chaque buildout doit définir obligatoirement une liste de ``parts``, mais
-   cette liste peut être vide. La liste indique ce qui doit être construit. 
+   cette liste peut être vide. La liste indique ce qui doit être construit.
    Si l'une des parts de la liste dépend d'autre parts, les autres parts
    seront elles-aussi construites.
 
@@ -453,7 +453,7 @@ buildout.cfg pour zope.event
    spécification de recette est une 'exigence' de distribution. L'exigence
    peut être suivie d'une virgule ou d'un nom de recette. Les eggs de recette
    peuvent contenir plusieurs recettes et peuvent définir une recette par défaut.
-   
+
    L'egg ``zc.recipe.testrunner`` définit une recette par défaut qui crée un
    lanceur de tests en utilisant le framework ``zope.testing.testrunner``.
 
@@ -505,9 +505,9 @@ buildout.cfg pour zope.event
 
      Buildout accepte plusieurs commandes. L'une d'entre elles est
      ``setup``.  La commande ``setup`` prend un nom de répertoire et
-     lance le script de setup trouvé à cet endroit. Il fait en sorte 
+     lance le script de setup trouvé à cet endroit. Il fait en sorte
      d'importer setuptools avant le lancement du script. Ceci permet aux
-     commandes définies par setuptools de fonctionner même pour les 
+     commandes définies par setuptools de fonctionner même pour les
      distributions qui n'utilisent pas setuptools.
 
      Les commandes sdist, register, upload, bdist_egg et egg_info sont
@@ -526,7 +526,7 @@ buildout.cfg pour zope.event
      L'option -r de la commande egg_info permet d'inclure le numéro de
      révision SVN du projet dans le numéro de version de la distribution.
      L'option -b précise un tag de révision. Ici on a spécifié un tag de
-     révision « dev » qui marque la publication comme une publication de 
+     révision « dev » qui marque la publication comme une publication de
      développement.
 
 Exercice 1
@@ -577,7 +577,7 @@ Organisation du buildout
 
 .. class:: handout
 
-   Certaines personnes trouvent l'organisation du buildout surprenant, car elle 
+   Certaines personnes trouvent l'organisation du buildout surprenant, car elle
    n'est pas semblable à l'organisation des répertoires d'un système unix. Cette
    organisation a été guidée par la règle « Mieux vaut plat qu'imbriqué ».
    ("Shallow is better than nested")
@@ -694,7 +694,7 @@ Un ``setup.py`` minimal ou de développement
          __path__ = pkgutil.extend_path(__path__, __name__)
 
    Les paquets d'espace de nom doivent être déclarés, comme on l'a fait ici.
-  
+
    Nous avons toujours intérêt à inclure les données du paquet.
 
    Comme le module `__init__` utilise setuptools, on le déclare comme dépendance,
@@ -860,7 +860,7 @@ Installation de scripts
    Si une distribution n'utilise pas setuptools, elle peut ne pas déclarer
    ses points d'entrée. Dans ce cas, vous pouvez spécifier les points d'entrée
    dans les données de la recette.
-  
+
 Initialisation des scripts
 ==========================
 
@@ -873,13 +873,13 @@ Initialisation des scripts
 
   [rst2]
   recipe = zc.recipe.egg
-  eggs = zc.rst2 
+  eggs = zc.rst2
          codeblock
-  initialization = 
+  initialization =
       sys.argv[1:1] = (
         's5 '
         '--stylesheet ${buildout:directory}/zope/docutils.css '
-        '--theme-url file://${buildout:directory}/zope' 
+        '--theme-url file://${buildout:directory}/zope'
         ).split()
   scripts = rst2=s5
 
@@ -890,7 +890,7 @@ Initialisation des scripts
 
    L'option d'initialisation nous permet de spécifier du code python à inclure.
 
-   Avec l'option 'scripts' on peut contrôler quels scripts sont installés et 
+   Avec l'option 'scripts' on peut contrôler quels scripts sont installés et
    quels sont leur nom. Dans cet exemple, on a utilisé l'option 'scripts' pour
    demander un script nommé ``s5`` depuis le point d'entrée ``rst2``.
 
@@ -916,7 +916,7 @@ Ceci entraînera la création d'un script ``bin/py``.
    Les interpréteurs personnalisés peuvent être utilisés pour obtenir
    une invite python avec les eggs spécifiés et leurs dépendances dans
    le ``sys.path``.
-   
+
    Vous pouvez aussi utiliser des interpréteurs personnalisés pour lancer
    des scripts, comme vous feriez avec l'interpréteur python habituel. Il
    suffit d'appeler l'interpréteur avec le chemin du script et ses arguments.
@@ -1020,7 +1020,7 @@ Personnalisation des Eggs en développement
          l'appel de l'initialisateur pour déterminer si une configuration
          a changé afin de savoir si une part doit être réinstallée.
          Une part est désinstallée avant d'être réinstallée.
-      
+
     - install
 
       .. class:: handout
@@ -1117,17 +1117,17 @@ Recettes de désinstallation
    import os
 
    class Service:
-   
+
        def __init__(self, buildout, name, options):
            self.options = options
-   
+
        def install(self):
-           os.system("chkconfig --add %s" % self.options['script'])         
+           os.system("chkconfig --add %s" % self.options['script'])
            return ()
-   
+
        def update(self):
            pass
-   
+
    def uninstall_service(name, options):
        os.system("chkconfig --del %s" % options['script'])
 
@@ -1156,7 +1156,7 @@ Points d'entrée de Buildout
    """
 
    setup(name='recipes', entry_points=entry_points)
-   
+
 Exercice 3
 ==========
 
@@ -1190,7 +1190,7 @@ Ligne de commande buildout :
    sur la ligne de commande sont prioritaires par rapport à celles des fichiers
    de configuration.
 
-   Il existe quelques options en ligne de commande, comme -c pour spécifier un 
+   Il existe quelques options en ligne de commande, comme -c pour spécifier un
    fichier de configuration ou -U pour désactiver la lecture des réglages par
    défaut de l'utilisateur.
 
@@ -1219,8 +1219,8 @@ Modes de Buildout
 .. class:: handout
 
    Par défaut, buildout essaie toujours de trouver les distributions les plus
-   récentes qui satisfassent les exigences. La recherche de nouvelles 
-   distributions peut prendre beaucoup de temps. De nombreuses personnes 
+   récentes qui satisfassent les exigences. La recherche de nouvelles
+   distributions peut prendre beaucoup de temps. De nombreuses personnes
    auront intérêt à utiliser l'option -N pour désactiver cette recherche.
    On verra plus loin comment modifier ce comportement par défaut.
 
@@ -1357,7 +1357,7 @@ Exemple: zc.sharing (1/2)
 ::
 
   [buildout]
-  develop = . zc.security 
+  develop = . zc.security
   parts = instance test
   find-links = http://download.zope.org/distribution/
 
@@ -1366,7 +1366,7 @@ Exemple: zc.sharing (1/2)
   database = data
   user = jim:123
   eggs = zc.sharing
-  zcml = 
+  zcml =
     zc.resourcelibrary zc.resourcelibrary-meta
     zc.sharing-overrides:configure.zcml zc.sharing-meta
     zc.sharing:privs.zcml zc.sharing:zope.manager-admin.zcml
@@ -1381,7 +1381,7 @@ Exemple: zc.sharing (1/2)
    Vous pouvez ignorer en grande partie les détails de la recette pour
    l'instance Zope 3. Si vous n'êtes pas un utilisateur de Zope, vous n'avez
    pas besoin de les connaître. Si vous êtes utilisateur de Zope, vous devez
-   savoir que de bien meilleures recettes sont développées. 
+   savoir que de bien meilleures recettes sont développées.
 
    Ce projet utilise plusieurs répertoire sources, le répertoire courant et le
    répertoire zc.security qui est une référence subversion externe vers un
@@ -1389,14 +1389,14 @@ Exemple: zc.sharing (1/2)
    l'option ``develop``.
 
    On a demandé les parts ``instance`` et ``test``. Des parts supplémentaires
-   seront installées à cause des dépendances de la part ``instance``. En 
+   seront installées à cause des dépendances de la part ``instance``. En
    particulier, on va obtenir un checkout de Zope3 parce que la recette
    ``instance`` fait référence à la part ``zope3``. On va obtenir une part
    ``database`` à cause de la référence de la recette ``instance`` dans l'option
    ``database``.
 
    Le buildout va chercher des distributionsn à l'adresse
-   http://download.zope.org/distribution/. 
+   http://download.zope.org/distribution/.
 
 Exemple: zc.sharing (2/2)
 =========================
@@ -1413,7 +1413,7 @@ Exemple: zc.sharing (2/2)
   [test]
   recipe = zc.recipe.testrunner
   defaults = ['--tests-pattern', 'f?tests$']
-  eggs = zc.sharing 
+  eggs = zc.sharing
          zc.security
   extra-paths = ${zope3:location}/src
 
@@ -1428,7 +1428,7 @@ Exemple: zc.sharing (2/2)
 
    - On a utilisé l'option ``extra-paths`` pour indiquer au lanceur de tests
      d'inclure le répertoire source du checkout de Zope 3  dans sys.path.
-     Ce n'est plus nécessaire puisque Zope 3 est maintenant disponible 
+     Ce n'est plus nécessaire puisque Zope 3 est maintenant disponible
      entièrement sous forme d'eggs.
 
 Source ou Binaire
@@ -1454,21 +1454,21 @@ Source ou Binaire
      Récemment, j'ai dû supprimer des eggs de mon répertoire d'eggs partagés.
      J'avais installé une mise à jour du système d'exploitation qui a causé
      des changements dans le nom des fichiers de la bibliothèque open-ssl.
-     Les eggs construits en utilisant la bibliothèque précédente ne 
-     fonctionnaient plus. 
+     Les eggs construits en utilisant la bibliothèque précédente ne
+     fonctionnaient plus.
 
 
 Expériences avec RPM
 ====================
 
-Travaux initiaux de création de RPMs pour le déploiement dans nos 
+Travaux initiaux de création de RPMs pour le déploiement dans nos
 environnements d'hébergement:
 
 - Séparation du logiciel et de sa configuration
 
 - Utilisation de Buildout pour créer des rpm contenant des programmes
 
-- Plus tard, le buildout installé est utilisé pour établir des procédures 
+- Plus tard, le buildout installé est utilisé pour établir des procédures
   spécifiques
 
   - Fonctionne en tant que root en mode hors-ligne
@@ -1515,7 +1515,7 @@ fichier de spec pour ZRS (1/3)
    RPMs python de façon à contrôler ce qu'ils contiennent. Les mainteneurs
    de paquets systèmes on tendance à être trop créatifs pour nous.
 
-   Habituellement, pendant la construction, RPM installe les fichiers dans 
+   Habituellement, pendant la construction, RPM installe les fichiers dans
    leur emplacement réel de fonctionnement. Ceci n'est pas acceptable pour de
    nombreuses raisons. J'ai ici utilisé le mécanisme build-root de RPM pour
    que les fichiers soient construits dans une arborescence temporaire..
@@ -1524,7 +1524,7 @@ fichier de spec pour ZRS (1/3)
    finale, les chemins écrits par le buildout, comme ceux des eggs dans
    les scripts, sont faux. Il existe deux moyens de pallier ce problème :
 
-   - Je pourrais essayer de corriger les chemins au moment de la construction, 
+   - Je pourrais essayer de corriger les chemins au moment de la construction,
 
    - je pourrais corriger les chemins au moment de l'installation.
 
@@ -1560,9 +1560,9 @@ fichier de spec pour ZRS (2/3)
 
 .. class:: handout
 
-   Je ne suis pas un expert de RPM, et de vrais experts en RPM auraient 
+   Je ne suis pas un expert de RPM, et de vrais experts en RPM auraient
    peut-être une contraction de l'estomac en voyant mon fichier de spec.
-   RPM spécifie normalement plusieurs étapes de construction que j'ai 
+   RPM spécifie normalement plusieurs étapes de construction que j'ai
    contractées en une seule.
 
    - Les premières lignes établissent une racine de construction.
@@ -1596,11 +1596,11 @@ fichier de spec pour ZRS (3/3)
   bin/buildout -Uc rpmpost.cfg \
      buildout:offline=true buildout:find-links= buildout:installed= \
      mercury:name=%{name} mercury:recipe=buildoutmercury
-  chmod -R -w . 
+  chmod -R -w .
 
   %preun
   cd $RPM_INSTALL_PREFIX/%{name}
-  chmod -R +w . 
+  chmod -R +w .
   find . -name \*.pyc | xargs rm -f
 
   %files
@@ -1646,9 +1646,9 @@ puis d'être capable de l'extraire et de la reproduire..
   distributions
 
   - On le lance avec l'option -v
-  
+
   - On recherche dans la sortie les lignes de la forme :
-  
+
     ::
 
       Picked: foo = 1.2
@@ -1664,14 +1664,14 @@ puis d'être capable de l'extraire et de la reproduire..
     [myversions]
     foo = 1.2
     ...
- 
+
 Problèmes de déploiement
 ========================
 
 - Besoin d'un moyen d'enregistrer les versions des eggs utilisés.
 
-- Besoin d'un moyen de générer des buildouts distribuables qui contiennent 
-  toutes les distributions sources nécessaires à la construction sur une 
+- Besoin d'un moyen de générer des buildouts distribuables qui contiennent
+  toutes les distributions sources nécessaires à la construction sur une
   machine cible (par ex les RPMS sources).
 
 - Besoin d'un moyen de générer des distributions sources. Il faudrait pouvoir

--- a/old-tutorial/tutorial.txt
+++ b/old-tutorial/tutorial.txt
@@ -61,7 +61,7 @@ Python-based
 
 - make is an awful scripting language
 
-  - uses shell 
+  - uses shell
 
   - non-portable
 
@@ -109,9 +109,9 @@ Working with eggs
     - always look for most recent versions by default
 
       .. class:: handout
-      
+
          When upgrading a distribution, ``easy_install`` doesn't upgrade
-         dependencies, 
+         dependencies,
 
     - support for custom build options
 
@@ -130,7 +130,7 @@ Working with eggs
      load the develop egg in preference to the non-develop egg.
 
      (``easy_install`` gives preference to released eggs of the same
-     version.) 
+     version.)
 
      When I'm done making my change, I make a new egg release and tell
      buildout to stop using a develop egg.
@@ -154,7 +154,7 @@ zc.buildout current status
      maintain and reuse.
 
      Two years ago, we created a prototype Python-based buildout
-     system. 
+     system.
 
      ``zc.buildout`` is a non-prototype system that reflects
      experience using the prototype.
@@ -219,7 +219,7 @@ Egg jargon
      Platform dependent eggs contain built extension modules and are
      thus tied to a specific operating system.  In addition, they may
      depend on build options that aren't reflected in the egg name.
-  
+
 - develop egg links
 
   .. class:: handout
@@ -227,7 +227,7 @@ Egg jargon
      Develop egg links (aka develop eggs) are special files that allow
      a source directory to be treated as an egg.  An egg links is a
      file containing the path of a source directory.
-  
+
 - requirements
 
   .. class:: handout
@@ -288,7 +288,7 @@ Entry points
 
        Buildout allows more control over script generation.
        Initialization code and entry point arguments can be
-       specified. 
+       specified.
 
 
 Buildout overview
@@ -311,16 +311,16 @@ Buildout overview
     .. class:: handout
 
        Although it is possible and common to factor into multiple
-       files. 
+       files.
 
 - Specify a set of "parts"
 
   - recipe
- 
+
   - configuration data
 
   .. class:: handout
-  
+
      Each part is defined by a recipe, which is Python software for
      installing or uninstalling the part, and data used by the recipe.
 
@@ -332,7 +332,7 @@ Buildout overview
 
      If a part's recipe or configuration changes, it is uninstalled
      and reinstalled.
-     
+
 
 Buildout overview (continued)
 =============================
@@ -389,7 +389,7 @@ Quick intro
 
      It is conventional to put a README.txt in the root of the
      project. distutils used to complain if this wasn't available.
-  
+
 - ``bootstrap.py`` for bootstrapping buildout
 
   .. class:: handout
@@ -403,7 +403,7 @@ zope.event buildout.cfg
 =======================
 
 ::
-  
+
   [buildout]
   parts = test
   develop = .
@@ -456,7 +456,7 @@ zope.event buildout.cfg
    recipe specification is a distribution requirement. The requirement
    may be followed by an colon and a recipe name.  Recipe eggs can
    contain multiple recipes and can also define an default recipe.
-   
+
    The ``zc.recipe.testrunner`` egg defines a default recipe that
    creates a test runner using the ``zope.testing.testrunner``
    framework.
@@ -584,7 +584,7 @@ buildout layout
 
    Some people find the buildout layout surprising, as it isn't
    similar to a Unix directory layout.  The buildout layout was guided
-   by "shallow is better than nested".  
+   by "shallow is better than nested".
 
    If you prefer a different layout, you can specify a different
    layout using buildout options.  You can set these options globally
@@ -605,7 +605,7 @@ Common buildout use cases
 
   - workingenv usually better
 
-  - buildout better when custom 
+  - buildout better when custom
     build options needed
 
 - Installing egg-based scripts for personal use
@@ -699,7 +699,7 @@ Distributable ``setup.py``
          __path__ = pkgutil.extend_path(__path__, __name__)
 
    Namespace packages have to be declared, as we've done here.
-  
+
    We always want to include package data.
 
    Because the `__init__` module uses setuptools, we declare it as a
@@ -865,7 +865,7 @@ Installing scripts
    points. In that case, you can specify entry points in the recipe data.
    Buildout *does* detect distutils-style scripts without an entry point and
    will generate a script for them when found.
-  
+
 Script initialization
 =====================
 
@@ -878,13 +878,13 @@ Script initialization
 
   [rst2]
   recipe = zc.recipe.egg
-  eggs = zc.rst2 
+  eggs = zc.rst2
          codeblock
-  initialization = 
+  initialization =
       sys.argv[1:1] = (
         's5 '
         '--stylesheet ${buildout:directory}/zope/docutils.css '
-        '--theme-url file://${buildout:directory}/zope' 
+        '--theme-url file://${buildout:directory}/zope'
         ).split()
   scripts = rst2=s5
 
@@ -921,7 +921,7 @@ This will cause a ``bin/py`` script to created.
 
    Custom interpreters can be used to get an interactive Python prompt
    with the specified eggs and and their dependencies on ``sys.path``.
-   
+
    You can also use custom interpreters to run scripts, just like you
    would with the usual Python interpreter.  Just call the interpreter
    with the script path and arguments, if any.
@@ -1024,7 +1024,7 @@ Writing recipes
          configuration has changed when deciding if a part has to
          be reinstalled.  When a part is reinstalled, it is
          uninstalled and then installed.
-      
+
     - install
 
       .. class:: handout
@@ -1045,7 +1045,7 @@ Writing recipes
          and it's configuration hasn't changed from previous
          buildouts.  It can return None or a sequence of paths. If
          paths are returned, they are added to the set of installed
-         paths. 
+         paths.
 
   - uninstall
 
@@ -1122,17 +1122,17 @@ Uninstall recipes
    import os
 
    class Service:
-   
+
        def __init__(self, buildout, name, options):
            self.options = options
-   
+
        def install(self):
-           os.system("chkconfig --add %s" % self.options['script'])         
+           os.system("chkconfig --add %s" % self.options['script'])
            return ()
-   
+
        def update(self):
            pass
-   
+
    def uninstall_service(name, options):
        os.system("chkconfig --del %s" % options['script'])
 
@@ -1161,7 +1161,7 @@ Buildout entry points
    """
 
    setup(name='recipes', entry_points=entry_points)
-   
+
 Exercise 3
 ==========
 
@@ -1274,7 +1274,7 @@ Extending configurations
 ========================
 
 The ``extends`` option allows one configuration file to extend
-another. 
+another.
 
 For example:
 
@@ -1359,7 +1359,7 @@ Example: zc.sharing (1/2)
 ::
 
   [buildout]
-  develop = . zc.security 
+  develop = . zc.security
   parts = instance test
   find-links = http://download.zope.org/distribution/
 
@@ -1368,7 +1368,7 @@ Example: zc.sharing (1/2)
   database = data
   user = jim:123
   eggs = zc.sharing
-  zcml = 
+  zcml =
     zc.resourcelibrary zc.resourcelibrary-meta
     zc.sharing-overrides:configure.zcml zc.sharing-meta
     zc.sharing:privs.zcml zc.sharing:zope.manager-admin.zcml
@@ -1382,7 +1382,7 @@ Example: zc.sharing (1/2)
 
    You can largely ignore the details of the Zope 3 instance  recipe.
    If you aren't a Zope user, you don't care.  If you are a Zope user,
-   you should be aware that much better recipes have been developed. 
+   you should be aware that much better recipes have been developed.
 
    This project uses multiple source directories, the current
    directory and the zc.security directory, which is a subversion
@@ -1396,7 +1396,7 @@ Example: zc.sharing (1/2)
    in the database option of the instance recipe.
 
    The buildout will look for distributions at
-   http://download.zope.org/distribution/. 
+   http://download.zope.org/distribution/.
 
 Example: zc.sharing (2/2)
 =========================
@@ -1413,7 +1413,7 @@ Example: zc.sharing (2/2)
   [test]
   recipe = zc.recipe.testrunner
   defaults = ['--tests-pattern', 'f?tests$']
-  eggs = zc.sharing 
+  eggs = zc.sharing
          zc.security
   extra-paths = ${zope3:location}/src
 
@@ -1451,7 +1451,7 @@ Source vs Binary
      Recently, I had to manually remove eggs from my shared eggs
      directory.  I had installed an operating system upgrade that
      caused the names of open-ssl library files to change.  Eggs build
-     against the old libraries no-longer functioned. 
+     against the old libraries no-longer functioned.
 
 
 RPM experiments
@@ -1461,7 +1461,7 @@ Initial work creating RPMs for deployment in our hosting environment:
 
 - Separation of software and configuration
 
-- Buildout used to create rpm containing software 
+- Buildout used to create rpm containing software
 
 - Later, the installed buildout is used to set up specific processes
 
@@ -1518,7 +1518,7 @@ ZRS spec file (1/3)
    location, paths written by the buildout, such as egg paths in
    scripts are wrong.  There are a couple of ways to deal with this:
 
-   - I could try to adjust the paths at build time, 
+   - I could try to adjust the paths at build time,
 
    - I could try to adjust the paths at install time.
 
@@ -1588,11 +1588,11 @@ ZRS spec file (3/3)
   bin/buildout -Uc rpmpost.cfg \
      buildout:offline=true buildout:find-links= buildout:installed= \
      mercury:name=%{name} mercury:recipe=buildoutmercury
-  chmod -R -w . 
+  chmod -R -w .
 
   %preun
   cd $RPM_INSTALL_PREFIX/%{name}
-  chmod -R +w . 
+  chmod -R +w .
   find . -name \*.pyc | xargs rm -f
 
   %files
@@ -1637,9 +1637,9 @@ be checked out and reproduced.
 - We let buildout tell what versions it picked for distributions
 
   - Run with -v
-  
+
   - Look for output lines of form:
-  
+
     ::
 
       Picked: foo = 1.2
@@ -1655,7 +1655,7 @@ be checked out and reproduced.
     [myversions]
     foo = 1.2
     ...
- 
+
 Deployment issues
 =================
 

--- a/specifications/README.txt
+++ b/specifications/README.txt
@@ -1,4 +1,4 @@
 This directory is (an experimental) place to manage Launchpad
 specification bodies.  Files here are referenced (via svn.zope.org
-URLs) from the buildout project specifications in Launchpad, 
+URLs) from the buildout project specifications in Launchpad,
 https://features.launchpad.net/products/zc.buildout.

--- a/specifications/repeatable.txt
+++ b/specifications/repeatable.txt
@@ -37,7 +37,7 @@ Consider the following example buildout.cfg::
 
   [foo]
   recipe = zc.recipe.eggs
-  eggs = foo 
+  eggs = foo
          eek
 
 Now assume that:
@@ -84,7 +84,7 @@ repeatable.cfg file::
 
   [foo]
   recipe = zc.recipe.eggs
-  eggs = foo 
+  eggs = foo
          eek
 
 When the buildout is run, the options in repeatable.cfg will override

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1426,7 +1426,7 @@ def _install_and_load(spec, group, entry, buildout):
             else:
                 dest = buildout_options['eggs-directory']
                 path = [buildout_options['develop-eggs-directory']]
-            
+
             # Pin versions when processing the buildout section
             versions_section_name = buildout['buildout'].get('versions', 'versions')
             versions = buildout.get(versions_section_name, {})

--- a/src/zc/buildout/tests/buildout.txt
+++ b/src/zc/buildout/tests/buildout.txt
@@ -1044,7 +1044,7 @@ Query values
 ------------
 
 For continuous integration, it might be useful to query the buildout config.
-    
+
     >>> write(sample_buildout, 'buildout.cfg',
     ... """
     ... [buildout]
@@ -1059,7 +1059,7 @@ For continuous integration, it might be useful to query the buildout config.
 
     >>> print_(system(buildout+ ' query buildout:develop'), end='')
     .
-    
+
     >>> print_(system(buildout+ ' query values:host'), end='')
     buildout.org
 
@@ -1073,7 +1073,7 @@ As with assignments, if the section is omitted, 'buildout' section is assumed.
     .
 
 When used with -v option, the query command also displays section and key.
-    
+
     >>> print_(system(buildout+ ' -v query develop'), end='')
     ${buildout:develop}
     .
@@ -1083,24 +1083,24 @@ When used with -v option, the query command also displays section and key.
     buildout.org
 
 The query commands outputs proper error messages.
-    
+
     >>> print_(system(buildout+ ' query versions parts'), end='')
     Error: The query command requires a single argument.
-    
+
     >>> print_(system(buildout+ ' query'), end='')
     Error: The query command requires a single argument.
-    
+
     >>> print_(system(buildout+ ' query invalid:section:key'), end='')
     Error: Invalid option: invalid:section:key
-    
+
     >>> print_(system(buildout+ ' -v query values:port'), end='')
     ${values:port}
     Error: Key not found: port
-    
+
     >>> print_(system(buildout+ ' -v query versionx'), end='')
     ${buildout:versionx}
     Error: Key not found: versionx
-    
+
     >>> print_(system(buildout+ ' -v query specific:port'), end='')
     ${specific:port}
     Error: Section not found: specific

--- a/src/zc/buildout/tests/debugging.txt
+++ b/src/zc/buildout/tests/debugging.txt
@@ -10,7 +10,7 @@ option to the buildout.  Let's create a recipe that has a bug:
 
     >>> mkdir(sample_buildout, 'recipes')
 
-    >>> write(sample_buildout, 'recipes', 'mkdir.py', 
+    >>> write(sample_buildout, 'recipes', 'mkdir.py',
     ... """
     ... import os, zc.buildout
     ...
@@ -35,7 +35,7 @@ option to the buildout.  Let's create a recipe that has a bug:
     >>> write(sample_buildout, 'recipes', 'setup.py',
     ... """
     ... from setuptools import setup
-    ... 
+    ...
     ... setup(name = "recipes",
     ...       entry_points = {'zc.buildout': ['mkdir = mkdir:Mkdir']},
     ...       )

--- a/src/zc/buildout/tests/dependencylinks.txt
+++ b/src/zc/buildout/tests/dependencylinks.txt
@@ -20,7 +20,7 @@ testing repository.
 
 Turn on logging on this server so that we can see when eggs are pulled
 from it.
-    
+
     >>> _ = get(link_server2 + 'enable_server_logging')
     GET 200 /enable_server_logging
 

--- a/src/zc/buildout/tests/runsetup.txt
+++ b/src/zc/buildout/tests/runsetup.txt
@@ -30,7 +30,7 @@ To illustrate this, we'll create a package in a sample buildout:
     ...       author_email="bob@foo.com",
     ...       )
     ... """)
-  
+
 We can use the buildout command to generate the hello egg:
 
     >>> print_(system(buildout +' setup hello -q bdist_egg'), end='')

--- a/src/zc/buildout/tests/test_increment.py
+++ b/src/zc/buildout/tests/test_increment.py
@@ -27,7 +27,7 @@ def default_cfg():
     >>> default_cfg = join(home, '.buildout', 'default.cfg')
     >>> write(default_cfg, '''
     ... [debug]
-    ... dec = 1 
+    ... dec = 1
     ...       2
     ... inc = 1
     ... ''')
@@ -97,7 +97,7 @@ def default_cfg_extensions():
     ...        },
     ...     )
     ... ''')
-    >>> write('buildout.cfg', ''' 
+    >>> write('buildout.cfg', '''
     ... [buildout]
     ... develop = demo demo2
     ... parts =
@@ -373,14 +373,14 @@ def no_default_with_extends_increment_in_base2_and_base3():
     ... parts =
     ... ''')
     >>> print_(system(buildout+' annotate buildout'), end='')
-    ... # doctest: +ELLIPSIS
+    ... # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     <BLANKLINE>
     Annotated sections
     ==================
     <BLANKLINE>
     [buildout]
     ...
-    extensions= 
+    extensions=
     demo2
     demo3
         IMPLICIT_VALUE

--- a/zc.recipe.egg_/README.rst
+++ b/zc.recipe.egg_/README.rst
@@ -5,6 +5,6 @@ Buildout Egg-Installation Recipe
 .. contents::
 
 The egg-installation recipe installs eggs into a buildout eggs
-directory.  It also generates scripts in a buildout bin directory with 
+directory.  It also generates scripts in a buildout bin directory with
 egg paths baked into them.
 

--- a/zc.recipe.egg_/src/zc/recipe/egg/api.rst
+++ b/zc.recipe.egg_/src/zc/recipe/egg/api.rst
@@ -15,7 +15,7 @@ To illustrate, we create a sample recipe that is a very thin layer
 around the egg recipe:
 
     >>> mkdir(sample_buildout, 'sample')
-    >>> write(sample_buildout, 'sample', 'sample.py', 
+    >>> write(sample_buildout, 'sample', 'sample.py',
     ... """
     ... import logging, os, sys
     ... import zc.recipe.egg
@@ -56,7 +56,7 @@ of extra requirements to be included in the working set.
     >>> write(sample_buildout, 'sample', 'setup.py',
     ... """
     ... from setuptools import setup
-    ... 
+    ...
     ... setup(
     ...     name = "sample",
     ...     entry_points = {'zc.buildout': ['default = sample:Sample']},
@@ -103,7 +103,7 @@ computed by the egg recipe by looking at .installed.cfg:
     parts = sample-part
     <BLANKLINE>
     [sample-part]
-    __buildout_installed__ = 
+    __buildout_installed__ =
     __buildout_signature__ = ...
     _b = /sample-buildout/bin
     _d = /sample-buildout/develop-eggs


### PR DESCRIPTION
My editor is configured to remove trailing whitespace on save. Several files that I touched lately would in this way get irrelevant changes, that I then mostly undid (using `git add --patch`) to avoid distracting reviewers. But now I removes all trailing whitespace.

That *did* lead to one test failure, which I fixed by normalizing whitespace in one doctest. Failure was (:

```
File "/Users/maurits/community/buildout/venvs/3.8/src/zc/buildout/tests/test_increment.py", line 375, in zc.buildout.tests.test_increment.no_default_with_extends_increment_in_base2_and_base3
Failed example:
    print_(system(buildout+' annotate buildout'), end='')
    # doctest: +ELLIPSIS
Expected:
    <BLANKLINE>
    Annotated sections
    ==================
    <BLANKLINE>
    [buildout]
    ...
    extensions=
    demo2
    demo3
        IMPLICIT_VALUE
    +=  base2.cfg
    +=  base3.cfg
    ...
    versions= versions
        DEFAULT_VALUE
Got:
```

And then under `GOT:` I got seemingly the same output. The difference was that we now expect `extensions=` and the output has `extensions= ` with a space at the end. I looked briefly at fixing that in the `annotate` command, but did not see how. So I added `+ELLIPSIS +NORMALIZE_WHITESPACE` to this doctest.