### PR TITLE
Test with latest setuptools 75.8.2, and with pip 25.0.1.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
-        setuptools-version: ["49.0.0", "59.8.0", "65.7.0", "69.5.1", "74.1.3", "75.6.0"]
+        setuptools-version: ["49.0.0", "59.8.0", "65.7.0", "69.5.1", "74.1.3", "75.6.0", "75.8.0", "75.8.1"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -82,8 +82,8 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
-        pip-version: ["20.3.4", "21.3.1", "22.3.1", "23.3.2", "24.3.1"]
-        setuptools-version: ["65.7.0", "75.6.0"]
+        pip-version: ["20.3.4", "21.3.1", "22.3.1", "23.3.2", "24.3.1", "25.0.1"]
+        setuptools-version: ["65.7.0", "75.8.1"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
-        setuptools-version: ["49.0.0", "59.8.0", "65.7.0", "69.5.1", "74.1.3", "75.6.0", "75.8.0", "75.8.1"]
+        setuptools-version: ["49.0.0", "59.8.0", "65.7.0", "69.5.1", "74.1.3", "75.8.2"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
         pip-version: ["20.3.4", "21.3.1", "22.3.1", "23.3.2", "24.3.1", "25.0.1"]
-        setuptools-version: ["65.7.0", "75.8.1"]
+        setuptools-version: ["65.7.0", "75.8.2"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
       matrix:
         os: [macos-latest]
         python-version: ["3.10"]
-        setuptools-version: ["75.6.0"]
+        setuptools-version: ["75.8.2"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -145,7 +145,7 @@ jobs:
       matrix:
         os: [windows-latest]
         python-version: ["3.10"]
-        setuptools-version: ["75.6.0"]
+        setuptools-version: ["75.8.2"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/news/7581.bugfix
+++ b/news/7581.bugfix
@@ -1,0 +1,4 @@
+When trying to find a distribution for ``package.name``, first try the normalized name (``package_name``).
+This fixes an error finding entry points for namespace packages.
+The error is: ``TypeError: ('Expected str, Requirement, or Distribution', None)``.
+[maurits]

--- a/news/7581.develop
+++ b/news/7581.develop
@@ -1,2 +1,3 @@
-Test with latest setuptools 75.8.0 and 75.8.1, and with pip 25.0.1.
+Test with latest ``setuptools`` 75.8.2 and with ``pip`` 25.0.1.
+Note that ``setuptools`` 75.8.1 can be troublesome and should be avoided.
 [maurits]

--- a/news/7581.develop
+++ b/news/7581.develop
@@ -1,0 +1,2 @@
+Test with latest setuptools 75.8.0 and 75.8.1, and with pip 25.0.1.
+[maurits]

--- a/news/7581.feature
+++ b/news/7581.feature
@@ -1,0 +1,5 @@
+In the ``ls`` testing method, add keyword argument ``lowercase_and_sort_output``.
+The default is False, so no change.
+When true, as the name says, it sorts the output by lowercase, and prints it lowercase.
+We need this in one test because with ``setuptools`` 75.8.1 we no longer have a filename ``MIXEDCASE-0.5-pyN.N.egg``, but ``mixedcase-0.5-pyN.N.egg``.
+[maurits]

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -20,6 +20,7 @@ from urllib.request import urlopen
 import errno
 import logging
 import multiprocessing
+import operator
 import os
 import pkg_resources
 import random
@@ -66,10 +67,14 @@ def clear_here():
         else:
             shutil.rmtree(name)
 
-def ls(dir, *subs):
+def ls(dir, *subs, lowercase_and_sort_output=False):
     if subs:
         dir = os.path.join(dir, *subs)
-    names = sorted(os.listdir(dir))
+    if lowercase_and_sort_output:
+        # Get the original names, but sorted lowercase.
+        names = sorted(os.listdir(dir), key=operator.methodcaller("lower"))
+    else:
+        names = sorted(os.listdir(dir))
     for name in names:
         # If we're running under coverage, elide coverage files
         if os.getenv("COVERAGE_PROCESS_START") and name.startswith('.coverage.'):
@@ -80,6 +85,8 @@ def ls(dir, *subs):
             print_('l ', end=' ')
         else:
             print_('- ', end=' ')
+        if lowercase_and_sort_output:
+            name = name.lower()
         print_(name)
 
 def mkdir(*path):

--- a/src/zc/buildout/tests/easy_install.txt
+++ b/src/zc/buildout/tests/easy_install.txt
@@ -258,7 +258,7 @@ Let's enable server logging to check that the lower case file is downloaded.
     GET 200 /demoneeded-1.1.zip
 
 Let's check that the uppercase dist is installed.
-setuptools 75.8 1+ reports the name in all lowercase, earlier versions showed it in uppercase.
+setuptools 75.8.1+ reports the name in all lowercase, earlier versions showed it in uppercase.
 So we compare lowercase.
 
     >>> for dist in ws:

--- a/src/zc/buildout/tests/easy_install.txt
+++ b/src/zc/buildout/tests/easy_install.txt
@@ -258,14 +258,16 @@ Let's enable server logging to check that the lower case file is downloaded.
     GET 200 /demoneeded-1.1.zip
 
 Let's check that the uppercase dist is installed.
+setuptools 75.8 1+ reports the name in all lowercase, earlier versions showed it in uppercase.
+So we compare lowercase.
 
     >>> for dist in ws:
-    ...     print_(dist)
+    ...     print_(str(dist).lower())
     demoneeded 1.1
-    MIXEDCASE 0.5
-    >>> ls(dest)
-    d  MIXEDCASE-0.5-pyN.N.egg
+    mixedcase 0.5
+    >>> ls(dest, lowercase_and_sort_output=True)
     d  demoneeded-1.1-py2.4.egg
+    d  mixedcase-0.5-pyN.N.egg
 
 And cleanup.
 
@@ -727,7 +729,7 @@ the path set:
                 # is isolated from the system Python already anyway.
                 # The specific use-case that led to this change is how the Python
                 # language extension for Visual Studio Code calls the Python
-                # interpreter when initializing the extension.              
+                # interpreter when initializing the extension.
                 pass
     <BLANKLINE>
         if _args:
@@ -1002,7 +1004,7 @@ We specified an interpreter and its paths are adjusted too:
                 # is isolated from the system Python already anyway.
                 # The specific use-case that led to this change is how the Python
                 # language extension for Visual Studio Code calls the Python
-                # interpreter when initializing the extension.              
+                # interpreter when initializing the extension.
                 pass
     <BLANKLINE>
         if _args:


### PR DESCRIPTION
I suspect 75.8.1 from yesterday will break for us due to changes in wheel names. Indeed this seems the case locally.  With 75.8.0 from early January I expect all is still fine.

[Update: original title was "Test with latest setuptools 75.8.0 and 75.8.1, and with pip 25.0.1."  Now I have updated the PR to test with latest 75.8.2.]