### PR TITLE
Fix error adding minimum ``zc.buildout`` version as requirement.

### DIFF
--- a/news/679.bugfix
+++ b/news/679.bugfix
@@ -1,0 +1,2 @@
+Fix error adding minimum ``zc.buildout`` version as requirement.
+[maurits]


### PR DESCRIPTION
Fixes https://github.com/buildout/buildout/issues/679

Also, previously the code was trying to get a distribution for `zc.buildout` even when it was not needed, that is when `zc.buildout` already had a version pin.