### PR TITLE
Fix error finding zc.buildout dist in upgrade check.

### DIFF
--- a/news/681.bugfix
+++ b/news/681.bugfix
@@ -1,4 +1,3 @@
 Fix error finding the ``zc.buildout`` distribution when checking if we need to upgrade/restart.
 This depends on your ``setuptools`` version.
-Additionally, check if we need to upgrade due to the new ``packaging`` dependency.
 [maurits]

--- a/news/681.bugfix
+++ b/news/681.bugfix
@@ -1,0 +1,4 @@
+Fix error finding the ``zc.buildout`` distribution when checking if we need to upgrade/restart.
+This depends on your ``setuptools`` version.
+Additionally, check if we need to upgrade due to the new ``packaging`` dependency.
+[maurits]

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1159,7 +1159,7 @@ class Buildout(DictMixin):
 
         upgraded = []
 
-        for project in 'zc.buildout', 'packaging', 'setuptools', 'pip', 'wheel':
+        for project in 'zc.buildout', 'setuptools', 'pip', 'wheel':
             canonicalized_name = packaging_utils.canonicalize_name(project)
             req = pkg_resources.Requirement.parse(canonicalized_name)
             dist = ws.find(req)

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -17,6 +17,7 @@
 from collections.abc import MutableMapping as DictMixin
 from functools import partial
 from hashlib import md5 as md5_original
+from packaging import utils as packaging_utils
 from zc.buildout.rmtree import rmtree
 
 import zc.buildout.easy_install
@@ -1158,10 +1159,25 @@ class Buildout(DictMixin):
 
         upgraded = []
 
-        for project in 'zc.buildout', 'setuptools', 'pip', 'wheel':
-            req = pkg_resources.Requirement.parse(project)
+        for project in 'zc.buildout', 'packaging', 'setuptools', 'pip', 'wheel':
+            canonicalized_name = packaging_utils.canonicalize_name(project)
+            req = pkg_resources.Requirement.parse(canonicalized_name)
             dist = ws.find(req)
+            if dist is None and canonicalized_name != project:
+                # Try with the original project name.  Depending on which setuptools
+                # version is used, this is either useless or a life saver.
+                req = pkg_resources.Requirement.parse(project)
+                dist = ws.find(req)
             importlib.import_module(project)
+            if dist is None:
+                # This is unexpected.  This must be some problem with how we use
+                # setuptools/pkg_resources.  But since the import worked, it feels
+                # safe to ignore.
+                self._logger.warning(
+                    "Could not find %s in working set during upgrade check. Ignoring.",
+                    project,
+                )
+                continue
             if not inspect.getfile(sys.modules[project]).startswith(dist.location):
                 upgraded.append(dist)
 


### PR DESCRIPTION
This depends on your `setuptools` version.
Additionally, check if we need to upgrade due to the new `packaging` dependency.

Fixes https://github.com/buildout/buildout/issues/681