### PR TITLE
Patch the find method from pkg_resources.WorkingSet.

### DIFF
--- a/news/682.bugfix
+++ b/news/682.bugfix
@@ -1,4 +1,5 @@
 Patch the ``find`` method from ``pkg_resources.WorkingSet``.
 Let this use the code from ``setuptools`` 75.8.2, if the currently used version is older.
 This is better at finding installed distributions.
+But don't patch ``setuptools`` versions older than 61: the new version of the method would give an error there.
 [maurits]

--- a/news/682.bugfix
+++ b/news/682.bugfix
@@ -1,0 +1,4 @@
+Patch the ``find`` method from ``pkg_resources.WorkingSet``.
+Let this use the code from ``setuptools`` 75.8.2, if the currently used version is older.
+This is better at finding installed distributions.
+[maurits]

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -317,14 +317,27 @@ def patch_pkg_resources_working_set_find():
 
     A lot of remaining problems in Buildout are fixed if we use this setuptools
     version.  So what we do in this patch, is to check which setuptools version
-    is used, and patch the 'find' method if the version is too old.
+    is used, and patch the 'find' method if the version is older than 75.8.2.
+
+    But: if the version is *much* older, the patch can be applied, but calling
+    the `find` method will raise:
+
+    AttributeError: 'WorkingSet' object has no attribute 'normalized_to_canonical_keys'
+
+    The first setuptools version that has this, is 61.0.0.
+    So don't patch versions that are older than that.
+
+    Alternatively, we could drop support.  That is fine with me.
     """
     try:
         from importlib.metadata import version
         from packaging.version import parse
         from packaging.version import Version
 
-        if parse(version("setuptools")) >= Version("75.8.2"):
+        setuptools_version = parse(version("setuptools"))
+        if setuptools_version >= Version("75.8.2"):
+            return
+        if setuptools_version < Version("61"):
             return
     except Exception:
         return

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -351,8 +351,12 @@ def patch_pkg_resources_working_set_find():
     except ImportError:
         return
 
-    def find(self, req: Requirement) -> Distribution | None:
+    def find(self, req):
         """Find a distribution matching requirement `req`
+
+        Note: I removed the type hints, because they failed on Python 3.9:
+
+          TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
 
         If there is an active distribution for the requested project, this
         returns it as long as it meets the version requirement specified by
@@ -361,7 +365,7 @@ def patch_pkg_resources_working_set_find():
         If there is no active distribution for the requested project, ``None``
         is returned.
         """
-        dist: Distribution | None = None
+        dist = None
 
         candidates = (
             req.key,


### PR DESCRIPTION
Let this use the code from `setuptools` 75.8.2, if the currently used version is older. This is better at finding installed distributions.

Fixes https://github.com/buildout/buildout/issues/683