### PR TITLE
If needed, copy and rename wheels before making an egg out of them.

### DIFF
--- a/news/686.bugfix
+++ b/news/686.bugfix
@@ -1,0 +1,4 @@
+If needed, copy and rename wheels before making an egg out of them.
+This helps for wheels of namespace packages created with ``setuptools`` 75.8.1 or higher.
+For namespace package we need a dot instead of an underscore in the resulting egg name.
+[maurits]


### PR DESCRIPTION
This helps for wheels of namespace packages created with `setuptools` 75.8.1 or higher. For namespace package we need a dot instead of an underscore in the resulting egg name.

Fixes https://github.com/buildout/buildout/issues/686