### PR TITLE
Test with setuptools 75.9.1 and 76.0.0.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
-        setuptools-version: ["49.0.0", "59.8.0", "65.7.0", "69.5.1", "74.1.3", "75.8.2"]
+        setuptools-version: ["49.0.0", "59.8.0", "65.7.0", "69.5.1", "74.1.3", "75.9.1", "76.0.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This is in the first batch of jobs where we test a range of setuptools versions. On some following jobs we still use 75.8.2.