### PR TITLE
Use version pins to determine which name to give to an egg.

### DIFF
--- a/news/695.feature
+++ b/news/695.feature
@@ -1,0 +1,3 @@
+Use version pins to determine which name to give to an egg.
+This fixes problems for dependencies of packages that were built by ``hatchling``.
+[maurits]


### PR DESCRIPTION
This fixes problems for dependencies of packages that were built by `hatchling`. Fixes issue #695.
Probably fixes issue #689 as well.

This builds on PR #675 because I want to have its test fixes.  But I first want that PR merged and released, so I will make this one a draft PR.  But locally it works as I want to, and the tests pass, so you can try it out.