### PR TITLE
Experiment: automatically use native namespaces.

### DIFF
--- a/news/695.feature
+++ b/news/695.feature
@@ -1,0 +1,3 @@
+Use version pins to determine which name to give to an egg.
+This fixes problems for dependencies of packages that were built by ``hatchling``.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     packages = ['zc', 'zc.buildout'],
     package_dir = {'': 'src'},
     python_requires = '>=3.9',
-    namespace_packages = ['zc'],
     install_requires = [
         'setuptools>=49.0.0',
         'packaging',

--- a/src/zc/__init__.py
+++ b/src/zc/__init__.py
@@ -1,5 +1,0 @@
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except:
-    # bootstrapping
-    pass

--- a/zc.recipe.egg_/setup.py
+++ b/zc.recipe.egg_/setup.py
@@ -69,7 +69,6 @@ setup(
 
     packages = find_packages('src'),
     package_dir = {'':'src'},
-    namespace_packages = ['zc', 'zc.recipe'],
     python_requires = '>=3.9',
     install_requires = [
         'zc.buildout >=4.0.0',

--- a/zc.recipe.egg_/src/zc/__init__.py
+++ b/zc.recipe.egg_/src/zc/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/zc.recipe.egg_/src/zc/recipe/__init__.py
+++ b/zc.recipe.egg_/src/zc/recipe/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)


### PR DESCRIPTION
This is an experiment for issue #676.
This builds on the branch for PR #696.

Previously, what we did when installing a distribution from PyPI:

* If it is a wheel, call the [`install_as_egg`](https://github.com/pypa/setuptools/blob/6ead555c5fb29bc57fe6105b1bffc163f56fd558/setuptools/wheel.py#L119) method of the wheel.  This transforms the `dist-info` directory to `EGG-INFO` and calls [`_fix_namespace_packages`](https://github.com/pypa/setuptools/blob/6ead555c5fb29bc57fe6105b1bffc163f56fd558/setuptools/wheel.py#L224) which adds `pkg_resources.declare_namespace` calls where needed.
* If it is a source dist, call `pip install` and then call [`make_egg_after_pip_install`](https://github.com/buildout/buildout/blob/de361650b60a3d0d4d4ad3f9268c077199850ce5/src/zc/buildout/easy_install.py#L1786) on the result.  This is similar to the `install_as_egg` method, and also adds `pkg_resources.declare_namespace` calls where needed.

With this PR:

* If it is a wheel, call [`setuptools.archive_util.unpack_zipfile`](https://github.com/pypa/setuptools/blob/6ead555c5fb29bc57fe6105b1bffc163f56fd558/setuptools/archive_util.py#L95).  So basically call `unzip` and we are done.
* If it is a source dist, call `pip install` and then nothing.
* The result is put in the (shared) eggs directory, even though it is not really an egg.  I let the name of the directory for each distribution end in `.experimental` so it can be easily found (and removed) if your shared eggs directory accidentally gets polluted with these.

This means that instead of unzipped eggs with an EGG-INFO directory, we have unzipped wheels with a dist-info directory.  In this scenario there are no pkg_resources-style namespaces: every namespace is native.  Technically this could be made optional, but for an experiment this is not needed, and we could skip that option completely.

I experimented with a buildout config from issue #695, a bit adapted:

```
[buildout]
# Do NOT use a shared eggs directory for this experiment!
eggs-directory = eggs
abi-tag-eggs = false
extends = https://dist.plone.org/release/6.1.1/versions.cfg
parts = instance

[instance]
recipe = plone.recipe.zope2instance
eggs =
    pas.plugins.authomatic
    plone.api
user = admin:admin
# This helps in case Products.CMFPlone is not correctly found by the recipe:
zodb-temporary-storage = off

[versions]
pas.plugins.authomatic = 2.0.0rc1
authomatic = 1.3.0
zc.buildout =
```

First create a virtualenv and do `bin/pip install -e path-to-buildout-checkout`, as described in that issue.  Then run `bin/buildout` and it simply works.

Actually, the changes that I am doing in PR #696 that try to rename a wheel before handling it, may not be needed in this scenario, nor the original renaming that that PR improves on.  If at the top of the `_move_to_eggs_dir_and_compile` I add a line `project_name = ""`, effectively ignoring the `project_name` argument, it still seems to work fine.  But it can be that this is only true for setuptools 75.8.2+.

Two details:

1. At first it failed for me after a while when the `plone.recipe.zope2instance` recipe tried to get the `zc.recipe.egg` distribution.  This just got installed, but could not be found.  Why?  Because the editable install of `zc.buildout` at that point still was using `pkg_resources`-style namespaces.  So I removed the `__init__.py` file in this PR (also from `zc.recipe.egg`).
2. When I run `make test` locally it quickly fails, see also [GitHub Actions](https://github.com/buildout/buildout/actions/runs/14229478591/job/39876791037?pr=697):

```
$ make test
bin/buildout || bin/buildout.exe
Develop: '/Users/maurits/community/buildout/zc.recipe.egg_'
Develop: '/Users/maurits/community/buildout/.'
...
While:
  Installing.
  Getting section test.
  Initializing section test.
  Loading zc.buildout recipe entry zc.recipe.testrunner:default.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 2329, in main
    getattr(buildout, command)(args)
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 753, in install
    [self[part]['recipe'] for part in install_parts]
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 753, in <listcomp>
    [self[part]['recipe'] for part in install_parts]
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 1405, in __getitem__
    options._initialize()
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 1517, in _initialize
    self.initialize()
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 1523, in initialize
    recipe_class = _install_and_load(reqs, 'zc.buildout', entry, buildout)
  File "/Users/maurits/community/buildout/src/zc/buildout/buildout.py", line 1477, in _install_and_load
    return pkg_resources.load_entry_point(
  File "/Users/maurits/community/buildout/venvs/python3/lib/python3.10/site-packages/pkg_resources/__init__.py", line 535, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/maurits/community/buildout/venvs/python3/lib/python3.10/site-packages/pkg_resources/__init__.py", line 3208, in load_entry_point
    return ep.load()
  File "/Users/maurits/community/buildout/venvs/python3/lib/python3.10/site-packages/pkg_resources/__init__.py", line 2778, in load
    return self.resolve()
  File "/Users/maurits/community/buildout/venvs/python3/lib/python3.10/site-packages/pkg_resources/__init__.py", line 2784, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/maurits/shared-eggs/cp310/zc.recipe.testrunner-2.0.0-py3.10-macosx-14.7-x86_64.egg/zc/recipe/testrunner/__init__.py", line 24, in <module>
    import zc.recipe.egg
ModuleNotFoundError: No module named 'zc.recipe.egg'
```

Possibly this could be solved by replacing [`pkg_resources.load_entry_point`](https://github.com/buildout/buildout/blob/de361650b60a3d0d4d4ad3f9268c077199850ce5/src/zc/buildout/buildout.py#L1477) with more modern `importlib.metadata` code.

Definitely do **NOT** use this in production!  But: I would be happy to get reports from people experimenting with this.

For something with that big of an impact, the git diff is actually pleasantly small. :-)

cc @ale-rt @davisagli @dataflake @icemac @gforcada.