### PR TITLE
Get actual project name from dist.

### DIFF
--- a/news/689.bugfix
+++ b/news/689.bugfix
@@ -1,0 +1,2 @@
+Use the canonical name of a package when checking for a version constraint.
+[maurits]

--- a/news/695.bugfix
+++ b/news/695.bugfix
@@ -1,0 +1,3 @@
+Get actual project name from dist.
+Use this for naming the egg that gets created after installing a wheel or after doing a pip install of a source dist.
+[maurits]


### PR DESCRIPTION
Use this for naming the egg that gets created after installing a wheel or after doing a pip install of a source dist. This fixes issue #695.

This replaces PR #696.

Also: use the canonical name of a package when checking for a version constraint. This fixes issue #689.

Combined, this fixes problems for dependencies of packages that were built by `hatchling`.

<s>Internal detail: changed `_maybe_copy_and_rename_wheel` to do only that: maybe copy and rename a wheel, and return that new wheel. Previously, `_move_to_eggs_dir_and_compile` would call this function, and if a rename was indeed needed, it would call `_move_to_eggs_dir_and_compile` with the new wheel and then return the egg. Now this function simply replaces one dist with another, and then `_move_to_eggs_dir_and_compile` continues where it left off.</s> [Update: that broke things, so I undid the change.]