### PR TITLE
Prevent getting package pages twice.

### DIFF
--- a/news/634.bugfix
+++ b/news/634.bugfix
@@ -1,0 +1,3 @@
+Prevent getting package pages twice.
+Since version 4.1.5 we first request normalized package url on PyPI servers, but a subsequent check needed a fix.
+[maurits]

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -408,7 +408,15 @@ def patch_find_packages():
         url_name = re.sub(r"[-_.]+", "-", requirement.unsafe_name).lower()
         self.scan_url(self.index_url + url_name + '/')
 
-        if not self.package_pages.get(requirement.key):
+        if self.package_pages.get(url_name):
+            # We have found a package page and don't need try to any other
+            # package pages for this package.
+            for url in list(self.package_pages.get(url_name)):
+                # scan each page that might be related to the desired package
+                self.scan_url(url)
+            return
+
+        if not self.package_pages.get(requirement.key) and requirement.key != url_name:
             # Fall back to safe version of the name
             self.scan_url(self.index_url + requirement.project_name + '/')
 

--- a/src/zc/buildout/tests/easy_install.txt
+++ b/src/zc/buildout/tests/easy_install.txt
@@ -254,7 +254,6 @@ Let's enable server logging to check that the lower case file is downloaded.
     ...     ['MIXEDCASE'], dest,
     ...     links=[link_server], index=link_server+'index/')
     GET 404 /index/mixedcase/
-    GET 404 /index/MIXEDCASE/
     GET 200 /mixedcase-0.5.tar.gz
     GET 200 /demoneeded-1.1.tar.gz
 


### PR DESCRIPTION
Since version 4.1.5 we first request normalized package url on PyPI servers, but a subsequent check needed a fix.

Sample output without this fix:

```
$ bin/buildout
...
root: Reading https://pypi.org/simple/zope-testrunner/
root: Reading https://pypi.org/simple/zope.testrunner/
Updating test.
root: Reading https://pypi.org/simple/zc-recipe-deployment/
root: Reading https://pypi.org/simple/zc.recipe.deployment/
root: Reading https://pypi.org/simple/zc-zdaemonrecipe/
root: Reading https://pypi.org/simple/zc.zdaemonrecipe/
root: Reading https://pypi.org/simple/zdaemon/
root: Reading https://pypi.org/simple/manuel/
root: Reading https://pypi.org/simple/six/
root: Reading https://pypi.org/simple/zconfig/
root: Reading https://pypi.org/simple/webob/
root: Reading https://pypi.org/simple/legacy-cgi/
Updating test-buildout.
Updating test-recipe.
Updating py.
Generated script '/Users/maurits/community/buildout/bin/buildout'.
```

Here we have a requirement `zope.testrunner`, so we normalize this name and get the PyPI index page for `zope-testrunner`.  This is good. But then the code checked if this call had gathered any package pages for the original name, which is naturally not the case. So the code got the PyPI page for `zope.testrunner`, which on the standard PyPI gets redirected to `zope-testrunner`, so we got the same url twice.

The fix now is: if you get the PyPI page for `zope-testrunner`, then also look for that name in the resulting package pages.

@andreclimaco This is an improvement on your merged PR #634.  Could you review this please?