### PR TITLE
Require at least `packaging` version 23.2.

### DIFF
--- a/news/700.bugfix
+++ b/news/700.bugfix
@@ -1,0 +1,3 @@
+Require at least `packaging` version 23.2.
+Needed because we use the `utils.is_normalized_name` function.
+[maurits]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     namespace_packages = ['zc'],
     install_requires = [
         'setuptools>=49.0.0',
-        'packaging',
+        'packaging>=23.2',
         'pip',
         'wheel',
     ],


### PR DESCRIPTION
Needed because we use the `utils.is_normalized_name` function. Fixes https://github.com/buildout/buildout/issues/700