### PR TITLE
Log all http errors when processing package url.

### DIFF
--- a/news/1013.bugfix
+++ b/news/1013.bugfix
@@ -1,0 +1,2 @@
+Log all http errors when processing package url.
+[maurits]

--- a/src/zc/buildout/patches.py
+++ b/src/zc/buildout/patches.py
@@ -115,8 +115,13 @@ def patch_PackageIndex():
         f = self.open_url(url, tmpl % url)
         if f is None:
             return
-        if isinstance(f, HTTPError) and f.code == 401:
-            self.info("Authentication error: %s" % f.msg)
+        # --- LOCAL CHANGES MADE HERE: ---
+        if isinstance(f, HTTPError):
+            if f.code == 401:
+                self.info("Authentication error: %s" % f.msg)
+            else:
+                self.info("HTTP error: %s" % f.msg)
+        # --- END OF LOCAL CHANGES ---
         self.fetched_urls[f.url] = True
         if 'html' not in f.headers.get('content-type', '').lower():
             f.close()  # not html, we can't process it


### PR DESCRIPTION
PyPI is having issues right now.  Sometimes I get a timeout, which is reported correctly. Other times I get an `HTTP Error 503: Service Unavailable`.  This is not reported, so you have no idea of the cause when later on this leads to a DistributionNotFound.

See https://github.com/plone/buildout.coredev/pull/1013#issuecomment-2785929350