### PR TITLE
Use wheel 0.45.1 when testing with setuptools older than 70.1.0.

### DIFF
--- a/news/705.tests
+++ b/news/705.tests
@@ -1,0 +1,3 @@
+Use ``wheel`` 0.45.1 when testing with ``setuptools`` older than 70.1.0.
+Otherwise, when combining an older ``setuptools`` with a newer ``wheel`` version, the ``bdist_wheel`` command exists in neither of these packages.
+[maurits]

--- a/prepare.sh
+++ b/prepare.sh
@@ -61,16 +61,37 @@ if test $PIP_VERSION; then
     # Make this '-U pip==version'.
 	PIP_ARGS="$PIP_ARGS==$PIP_VERSION"
 fi
+WHEEL_VERSION=""
 PIP_ARGS="$PIP_ARGS setuptools"
 if test $SETUPTOOLS_VERSION; then
 	PIP_ARGS="$PIP_ARGS==$SETUPTOOLS_VERSION"
+  # wheel is a dependency of zc.buildout, but we may need a specific version.
+  # If we use setuptools older than 70.1.0, we must use at most wheel 0.45.1,
+  # otherwise the bdist_wheel command is not present.
+  # Sorry, this will be some ugly bash stuff.
+  # 1. Get rid of the first dot in the version: 69.5.1 -> 695.1
+  SV="${SETUPTOOLS_VERSION/./}"
+  # 2. Take only the first three characters: 695.1 -> 695
+  SV="${SV:0:3}"
+  # 3. Do the same two transformations on the target version:
+  # 70.1.0 -> 701.0 -> 701.  Check if the SETUPTOOLS_VERSION is lighter.
+  if test $SV -lt 701; then
+    WHEEL_VERSION="0.45.1"
+    echo "Pinning wheel to $WHEEL_VERSION for compat with older setuptools."
+  fi
 fi
-# wheel and packaging are already dependencies of zc.buildout.
+# Always include wheel:
+PIP_ARGS="$PIP_ARGS wheel"
+if test $WHEEL_VERSION; then
+  # Use a specific version:
+	PIP_ARGS="$PIP_ARGS==$WHEEL_VERSION"
+fi
+# packaging is already a dependency of zc.buildout, but we explicitly add it.
 # We add 'build' so we can build a source dist of zc.buildout,
 # which has a side effect we need: generate 'src/zc.buildout.egg-info'
 # This is needed so in Python we can do:
 # >>> pkg_resources.working_set.add_entry('src')
-PIP_ARGS="$PIP_ARGS wheel packaging build"
+PIP_ARGS="$PIP_ARGS packaging build"
 echo
 echo "Using arguments for pip install: $PIP_ARGS"
 # "$VENV_PYTHON" -m pip install -e .[test] -e zc.recipe.egg_[test] $PIP_ARGS

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Note: if you are testing changes, you may want to temporarily change the line
+# above to use /bin/dash instead of bash.  Otherwise you may get incompatibilities.
 # Exit on error:
 set -e
 HERE="$PWD"
@@ -68,13 +70,10 @@ if test $SETUPTOOLS_VERSION; then
   # wheel is a dependency of zc.buildout, but we may need a specific version.
   # If we use setuptools older than 70.1.0, we must use at most wheel 0.45.1,
   # otherwise the bdist_wheel command is not present.
-  # Sorry, this will be some ugly bash stuff.
-  # 1. Get rid of the first dot in the version: 69.5.1 -> 695.1
-  SV="${SETUPTOOLS_VERSION/./}"
-  # 2. Take only the first three characters: 695.1 -> 695
-  SV="${SV:0:3}"
-  # 3. Do the same two transformations on the target version:
-  # 70.1.0 -> 701.0 -> 701.  Check if the SETUPTOOLS_VERSION is lighter.
+  # Take the major and minor version and remove the dot: 69.5.1 -> 695
+  SV=$(echo $SETUPTOOLS_VERSION | cut -d "." -f-2 | sed "s/\.//")
+  # Do the same transformation on the target version: 70.1.0 -> 701.
+  # Check if the SETUPTOOLS_VERSION is lighter than the target.
   if test $SV -lt 701; then
     WHEEL_VERSION="0.45.1"
     echo "Pinning wheel to $WHEEL_VERSION for compat with older setuptools."


### PR DESCRIPTION
Otherwise, when combining an older `setuptools` with a newer `wheel` version, the `bdist_wheel` command exists in neither of these packages.

Fixes https://github.com/buildout/buildout/issues/705

Note: with newer setuptools, our script does not guarantee that you actually get the latest `wheel` package.  I expected this, but this may depend on what you already have installed in your main Python install.