### PR TITLE
Patch pkg_resources.get_supported_platform for better results on Mac

### DIFF
--- a/news/609.bugfix
+++ b/news/609.bugfix
@@ -1,0 +1,4 @@
+Patch `pkg_resources.get_supported_platform` to have better results on Mac.
+Without this, a freshly created Mac-specific egg may not be considered compatible.
+This can happen when the Python you use was built on a different Mac OSX version.
+[maurits]

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -165,9 +165,9 @@ class Environment(EnvironmentMixin, pkg_resources.Environment):
     """
     def __init__(
         self,
-        search_path: Iterable[str] | None = None,
-        platform: str | None = pkg_resources.get_supported_platform(),
-        python: str | None = PY_MAJOR,
+        search_path=None,
+        platform=pkg_resources.get_supported_platform(),
+        python=PY_MAJOR,
     ) -> None:
         """Snapshot distributions available on a search path
 

--- a/src/zc/buildout/tests/easy_install.txt
+++ b/src/zc/buildout/tests/easy_install.txt
@@ -334,6 +334,16 @@ reporting that a version was picked automatically:
       Getting distribution for 'demo'.
     zc.buildout.easy_install DEBUG
       Fetching demo 0.3 from: http://.../demo-0.3-py3-none-any.whl
+    zc.buildout.easy_install DEBUG
+      Turning dist demo 0.3 (.../demo-0.3-py3-none-any.whl) into egg, and moving to eggs dir /sample-install).
+    zc.buildout.easy_install DEBUG
+      Checking if wheel needs to be renamed.
+    zc.buildout.easy_install DEBUG
+      Renaming wheel was not needed or did not help.
+    zc.buildout.easy_install DEBUG
+      Calling unpacker for .whl on .../demo-0.3-py3-none-any.whl
+    zc.buildout.easy_install DEBUG
+      Egg for demo 0.3 installed at .../demo-0.3-pyN.N.egg
     zc.buildout.easy_install INFO
       Got demo 0.3.
     zc.buildout.easy_install DEBUG
@@ -347,28 +357,17 @@ reporting that a version was picked automatically:
     zc.buildout.easy_install DEBUG
       Fetching demoneeded 1.1 from: http://.../demoneeded-1.1.tar.gz
     zc.buildout.easy_install DEBUG
+      Turning dist demoneeded 1.1 (.../demoneeded-1.1.tar.gz) into egg, and moving to eggs dir /sample-install).
+    zc.buildout.easy_install DEBUG
+      Calling pip install for .gz on .../demoneeded-1.1.tar.gz
+    zc.buildout.easy_install DEBUG
       Running pip install:...
+    zc.buildout.easy_install DEBUG
+      Egg for demoneeded 1.1 installed at .../demoneeded-1.1-pyN.N.egg
     zc.buildout.easy_install INFO
       Got demoneeded 1.1.
     zc.buildout.easy_install DEBUG
       Picked: demoneeded = 1.1
-
-
-    zc.buildout.easy_install DEBUG
-      Installing 'demo'.
-    zc.buildout.easy_install DEBUG
-      We have the best distribution that satisfies 'demo'.
-    zc.buildout.easy_install DEBUG
-      Picked: demo = 0.3
-    zc.buildout.easy_install DEBUG
-      Getting required 'demoneeded'
-    zc.buildout.easy_install DEBUG
-        required by demo 0.3.
-    zc.buildout.easy_install DEBUG
-      We have the best distribution that satisfies 'demoneeded'.
-    zc.buildout.easy_install DEBUG
-      Picked: demoneeded = 1.1
-
     >>> handler.uninstall()
     >>> logging.getLogger('zc.buildout.easy_install').propagate = True
 


### PR DESCRIPTION
The patch is only applied on Mac: other platforms seem not affected. Also added some `logger.debug` lines in `_move_to_eggs_dir_and_compile`.

See original report by @dataflake a few years ago for setuptools: https://github.com/pypa/setuptools/issues/3687

And his [comment in zopefoundation/meta](https://github.com/zopefoundation/meta/issues/181#issuecomment-1757558915) explains well what happens from the standpoint of Buildout.

Nowadays, the same can happen with a Python installed by uv, as I saw today:

```
% bin/zopepy
>>> import pkg_resources
>>> pkg_resources.get_platform()
'macosx-11.0-arm64'
>>> pkg_resources.get_supported_platform()
'macosx-15.4-arm64'
```

Here macosx-11.0 is the platform on which the Python was built/compiled. And macosx-15.4 is the current platform (my laptop).

This gives problems when we get a Mac-specific wheel.  We turn it into an egg that has the result of get_supported_platform() in its name. Then our code in easy_install._get_matching_dist_in_location creates a pkg_resources.Environment with the egg location.  Under the hood, pkg_resources.compatible_platforms is called, and this does not find any matching dists because it compares the platform in the egg name with that of the system, which is pkg_resources.get_platform().

As far as I see, only Mac has this problem, depending on your Python and on the packages that you install:

- uv installs a pre-built Python, so the platforms likely differ.
- When using pyenv, you compile a Python locally, so both platforms are exactly the same, so there is no problem.
- When you upgrade to a new Mac OSX version, but keep the previously compiled pyenv, the platforms will differ.  You should reinstall all pyenv Pythons. But this patch should fix that.
- Wheels with only Python code (no C, Rust, etc), will have a name ending in py3-none-any.whl, and this does not suffer from this problem.

Note: after having seen this, I plan to not actually use `uv` when creating a buildout. With this PR it should work, but I have seen other unexpected behavior that is likely to cause problems, or at least to require changes in how my workflow:

```
% uv venv foo
Using CPython 3.13.3
Creating virtual environment at: foo
Activate with: source foo/bin/activate
% source foo/bin/activate
% python -m pip
/Users/maurits/foo/bin/python: No module named pip
% which pip
pip not found
```

In another case I saw this:

```
% bin/python
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Fatal Python error: Failed to import encodings module
Python runtime state: core initialized
ModuleNotFoundError: No module named 'encodings'

Current thread 0x0000000200534c80 (most recent call first):
  <no Python frame>
```

So: `uv` is nice and fast, but I currently don't fully trust it in combination with Buildout.