### PR TITLE
Override pkg_resources.Environment.can_add to have better results on Mac

### DIFF
--- a/.github/workflows/Makefile-scripts
+++ b/.github/workflows/Makefile-scripts
@@ -1,7 +1,7 @@
 sandbox/bin/python:
 	pip install virtualenv
 	virtualenv sandbox
-	sandbox/bin/python -mpip install setuptools
+	sandbox/bin/python -mpip install 'setuptools<80'
 
 sandbox/bin/buildout: sandbox/bin/python
 	sandbox/bin/python setup.py develop

--- a/news/609.bugfix
+++ b/news/609.bugfix
@@ -1,0 +1,4 @@
+Override `pkg_resources.Environment.can_add` to have better results on Mac.
+Without this, a freshly created Mac-specific egg may not be considered compatible.
+This can happen when the Python you use was built on a different Mac OSX version.
+[maurits]

--- a/prepare.sh
+++ b/prepare.sh
@@ -9,6 +9,12 @@ PYTHON_VERSION="${PYTHON_VERSION:-3}"
 PIP_VERSION="${PIP_VERSION}"
 SETUPTOOLS_VERSION="${SETUPTOOLS_VERSION}"
 PIP_ARGS="${PIP_ARGS:--U}"
+USE_UV="${USE_UV}"
+if test "$USE_UV"; then
+    UV_LINE="YES (override by unsetting USE_UV environment variable or making it empty)"
+else
+    UV_LINE="NO (override by giving USE_UV environment variable a non-empty value)"
+fi
 cat << MARKER
 Prepare a virtual environment for testing zc.buildout.
 
@@ -16,6 +22,7 @@ Using:
 * Python: $PYTHON_VERSION (override with PYTHON_VERSION environment variable)
 * pip: $PIP_VERSION (override with PIP_VERSION environment variable)
 * setuptools: $SETUPTOOLS_VERSION (override with SETUPTOOLS_VERSION environment variable)
+* use uv: $UV_LINE
 
 An empty version means: use whatever is already available, or install latest.
 Extra arguments for pip install: $PIP_ARGS (override with PIP_ARGS environment variable)
@@ -54,7 +61,12 @@ $PYTHON --version
 echo
 echo "Creating virtual environment in $VENV"
 mkdir -p "$VENVS"
-$PYTHON -m venv "$VENV"
+if test "$USE_UV"; then
+  echo "using uv"
+  uv venv -p $PYTHON_VERSION --seed "$VENV"
+else
+  $PYTHON -m venv "$VENV"
+fi
 
 PIP_ARGS="$PIP_ARGS pip"
 if test $PIP_VERSION; then

--- a/src/zc/buildout/tests/easy_install.txt
+++ b/src/zc/buildout/tests/easy_install.txt
@@ -334,6 +334,16 @@ reporting that a version was picked automatically:
       Getting distribution for 'demo'.
     zc.buildout.easy_install DEBUG
       Fetching demo 0.3 from: http://.../demo-0.3-py3-none-any.whl
+    zc.buildout.easy_install DEBUG
+      Turning dist demo 0.3 (.../demo-0.3-py3-none-any.whl) into egg, and moving to eggs dir /sample-install).
+    zc.buildout.easy_install DEBUG
+      Checking if wheel needs to be renamed.
+    zc.buildout.easy_install DEBUG
+      Renaming wheel was not needed or did not help.
+    zc.buildout.easy_install DEBUG
+      Calling unpacker for .whl on .../demo-0.3-py3-none-any.whl
+    zc.buildout.easy_install DEBUG
+      Egg for demo 0.3 installed at .../demo-0.3-pyN.N.egg
     zc.buildout.easy_install INFO
       Got demo 0.3.
     zc.buildout.easy_install DEBUG
@@ -347,28 +357,17 @@ reporting that a version was picked automatically:
     zc.buildout.easy_install DEBUG
       Fetching demoneeded 1.1 from: http://.../demoneeded-1.1.tar.gz
     zc.buildout.easy_install DEBUG
+      Turning dist demoneeded 1.1 (.../demoneeded-1.1.tar.gz) into egg, and moving to eggs dir /sample-install).
+    zc.buildout.easy_install DEBUG
+      Calling pip install for .gz on .../demoneeded-1.1.tar.gz
+    zc.buildout.easy_install DEBUG
       Running pip install:...
+    zc.buildout.easy_install DEBUG
+      Egg for demoneeded 1.1 installed at .../demoneeded-1.1-pyN.N.egg
     zc.buildout.easy_install INFO
       Got demoneeded 1.1.
     zc.buildout.easy_install DEBUG
       Picked: demoneeded = 1.1
-
-
-    zc.buildout.easy_install DEBUG
-      Installing 'demo'.
-    zc.buildout.easy_install DEBUG
-      We have the best distribution that satisfies 'demo'.
-    zc.buildout.easy_install DEBUG
-      Picked: demo = 0.3
-    zc.buildout.easy_install DEBUG
-      Getting required 'demoneeded'
-    zc.buildout.easy_install DEBUG
-        required by demo 0.3.
-    zc.buildout.easy_install DEBUG
-      We have the best distribution that satisfies 'demoneeded'.
-    zc.buildout.easy_install DEBUG
-      Picked: demoneeded = 1.1
-
     >>> handler.uninstall()
     >>> logging.getLogger('zc.buildout.easy_install').propagate = True
 


### PR DESCRIPTION
The override only changes the result on Mac: other platforms seem not affected.
This replaces my PRs #707 and #709.

Two minor other changes in here:

* Added some `logger.debug` lines in `_move_to_eggs_dir_and_compile`.
* Added option to use uv for creating the test environment by setting environment variable USE_UV a non-empty value.  We don't use this in our current test setup on GitHub Actions though.

See original report by Jens Vagelpohl a few years ago for setuptools: https://github.com/pypa/setuptools/issues/3687

And his comment in zopefoundation/meta explains well what happens from the standpoint of Buildout:
https://github.com/zopefoundation/meta/issues/181#issuecomment-1757558915

Nowadays, the same can happen with a Python installed by uv, as I saw today:

```
% bin/zopepy
>>> import pkg_resources
>>> pkg_resources.get_platform()
'macosx-11.0-arm64'
>>> pkg_resources.get_supported_platform()
'macosx-15.4-arm64'
```

Here `macosx-11.0` is the platform on which the Python was built/compiled. And `macosx-15.4` is the current platform (my laptop).

This gives problems when we get a Mac-specific wheel.  We turn it into an egg that has the result of `pkg_resources.get_supported_platform()` in its name. Then our code in `easy_install._get_matching_dist_in_location` creates a `pkg_resources.Environment` with the egg location.  Under the hood, `pkg_resources.compatible_platforms` is called, and this does not find any matching dists because it compares the platform in the egg name with that of the system, which is `pkg_resources.get_platform()`.

As far as I see, only Mac has this problem, depending on your Python and on the packages that you install:

- uv installs a pre-built Python, so the platforms likely differ. But this PR should fix that.
- When using pyenv, you compile a Python locally, so both platforms are exactly the same, so there is no problem.
- When you upgrade to a new Mac OSX version, but keep the previously compiled pyenv, the platforms will differ. You should reinstall all pyenv Pythons.  But this PR should fix that.
- Wheels with only Python code (no C, Rust, etc), will have a name ending in py3-none-any.whl, and this does not suffer from this problem.