### PR TITLE
Editable installs: try to use 'pth' files created by pip [this fails]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ venvs/
 *.pyc
 *.egg
 *.egg-info
+*.dist-info
 dist
 .tox
 .coverage

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ help:
 	./prepare.sh --help
 
 clean:
-	rm -rf venvs .Python .installed.cfg bin build dist lib include parts pip-selfcheck.json develop-eggs src/*.egg-info zc.recipe.egg_/src/*.egg-info
+	rm -rf venvs .Python .installed.cfg bin build dist lib include parts pip-selfcheck.json develop-eggs src/*.*-info zc.recipe.egg_/src/*.*-info

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,9 +1,12 @@
 [buildout]
-develop = zc.recipe.egg_ .
-parts = test test-buildout test-recipe py
+develop = zc.recipe.egg_ . showversions
+parts = show-versions test test-buildout test-recipe py
 versions = versions
 eggs-directory = eggs
 download-cache = downloads
+
+[show-versions]
+recipe = showversions
 
 [versions]
 zope.interface = 4.1.3

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'packaging>=23.2',
         'pip',
         'wheel',
+        "importlib-metadata; python_version<'3.10'",
     ],
     include_package_data = True,
     entry_points = entry_points,

--- a/showversions/pyproject.toml
+++ b/showversions/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<75", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/showversions/setup.py
+++ b/showversions/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup
+
+setup(
+    name = "showversions",
+    entry_points = {'zc.buildout': ['default = showversions:Recipe']},
+)

--- a/showversions/showversions.py
+++ b/showversions/showversions.py
@@ -1,0 +1,14 @@
+import pkg_resources
+import sys
+
+print_ = lambda *a: sys.stdout.write(' '.join(map(str, a))+'\\n')
+
+class Recipe:
+    def __init__(self, buildout, name, options):
+        pass
+    def install(self):
+        for project in ['zc.buildout']:
+            req = pkg_resources.Requirement.parse(project)
+            print_(project, pkg_resources.working_set.find(req).version)
+        return ()
+    update = install

--- a/src/zc/buildout/buildout.py
+++ b/src/zc/buildout/buildout.py
@@ -1017,10 +1017,15 @@ class Buildout(DictMixin):
 
     def _develop_eggs_entry_is_sane(self, entry):
         if os.path.isdir(entry):
+            if entry.name == '__pycache__':
+                return True
             return entry.name.endswith('.dist-info')
         if not os.path.isfile(entry):
             return False
-        return entry.name.endswith('.pth') or entry.name.endswith('.egg-link')
+        for suffix in ('.pth', '.py', '.egg-link'):
+            if entry.name.endswith(suffix):
+                return True
+        return False
 
     def _sanity_check_develop_eggs_files(self, dest, old_files):
         dest = Path(dest)

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -424,7 +424,7 @@ class Installer(object):
             for pth_file in Path(path).glob('*.pth'):
                 source = get_source_from_pth_file(pth_file)
                 if source:
-                    full_path.append(source)
+                    full_path.append(str(source.absolute()))
         env = Environment(full_path)
         # this needs to be called whenever self._env is modified (or we could
         # make an Environment subclass):

--- a/src/zc/buildout/utils.py
+++ b/src/zc/buildout/utils.py
@@ -1,4 +1,5 @@
 from importlib.metadata import version
+from pathlib import Path
 
 import packaging.version
 import re
@@ -20,3 +21,20 @@ def normalize_name(name):
     which turns "foo.bar" into "foo-bar", so it is different.
     """
     return re.sub(r"[-_.]+", "-", name).lower().replace('-', '_')
+
+
+def get_source_from_pth_file(pth_file):
+    """Read .pth file and extract the source path it points to.
+
+    Lines in .pth files are either comments, import statements, or
+    paths to directories.
+    """
+    # pth_file should be a Path object.
+    text = pth_file.read_text()
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#') or line.startswith('import '):
+            continue
+        line = Path(line)
+        if line.exists():
+            return line


### PR DESCRIPTION
These are some commits that I initially added to my PR #720 (work in progress) but that did not work, so I took them out.  These commits are about editable installs (so the `buildout:develop` option).  In the original PR I seem to have this working, though I want to do more testing, especially add tests with non-setuptools packages.  With setuptools older than 80, an egg-link file is automatically created for us by setuptools.  With setuptools 80+, this is no longer the case.  So in that other PR I manually create an `egg-link` file.  All current GitHub Actions tests actually pass there.

But 'manually' creating an egg-link file feels a bit brittle, and I think I already saw it does not work for non-setuptools packages (but I need to test that again).  So I tried using the `.pth` file and `.dist-info` directory that pip creates.

With the first two commits of this PR, it actually works locally with setuptools 75.8.2.  But with latest setuptools, there are a lot of test failures: mostly all kinds of packages can't be found after installation.  The other commits try to fix this, but then it just fails on all setuptools versions.

I may need some of this after all, so I want to keep these commits in a visible place.