### PR TITLE
Fix script tests by not testing on Python 3.9.

### DIFF
--- a/.github/workflows/scripts-setuptools-head.yml
+++ b/.github/workflows/scripts-setuptools-head.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         package: [zest.releaser, pyspf]
 
     steps:

--- a/news/+5c1644fe.tests.rst
+++ b/news/+5c1644fe.tests.rst
@@ -1,0 +1,1 @@
+Fix script tests.  [maurits]


### PR DESCRIPTION
They [failed since 13 April](https://github.com/buildout/buildout/actions/runs/24347417557/job/71092042746) because setuptools HEAD requires Python 3.10+.

They still [passed before that](https://github.com/buildout/buildout/actions/runs/24324527963/job/71017090977#step:4:122). But as you can see in that link:

```
Successfully installed packaging-26.0 setuptools-81.0.0 wheel-0.46.3 zc.buildout-5.1.4.dev0
```

So initially the `setuptools` main branch is used for a development installation, but then the `zc.buildout` requirement `setuptools<82` kicks in. So these tests don't actually do what they say: they don't test setuptools HEAD.

But that is a different issue.