### PR TITLE
Allow setuptools 82 and later

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
-        setuptools-version: ["63.0.0", "65.7.0", "69.5.1", "74.1.3", "75.9.1", "79.0.1", "80.2.0", "80.10.2", "81.0.0"]
+        # 82.0.1 and later no longer contain pkg_resources;
+        # buildout uses its own vendored copy on all versions.
+        setuptools-version: ["63.0.0", "65.7.0", "69.5.1", "74.1.3", "75.9.1", "79.0.1", "80.2.0", "80.10.2", "81.0.0", "82.0.1", "83.0.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6.0.2
@@ -75,6 +77,15 @@ jobs:
         # Use the last setuptools version that is still supported by all Python versions.
         python-version: ["3.9", "3.11", "3.12", "3.13", "3.14"]
         setuptools-version: ["75.6.0"]
+        include:
+          # setuptools 82.0.1 is the newest version supporting Python 3.9.
+          - os: ubuntu-24.04
+            python-version: "3.9"
+            setuptools-version: "82.0.1"
+          # Newest Python with newest setuptools (requires Python >= 3.10).
+          - os: ubuntu-24.04
+            python-version: "3.14"
+            setuptools-version: "83.0.0"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6.0.2
@@ -128,7 +139,7 @@ jobs:
       matrix:
         os: [macos-latest]
         python-version: ["3.10"]
-        setuptools-version: ["75.8.2"]
+        setuptools-version: ["83.0.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6.0.2
@@ -156,7 +167,9 @@ jobs:
       matrix:
         os: [windows-latest]
         python-version: ["3.10"]
-        setuptools-version: ["75.8.2"]
+        # The newest setuptools exercises the Windows script generation
+        # (cli.exe) with a setuptools that no longer ships pkg_resources.
+        setuptools-version: ["83.0.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6.0.2

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,9 @@ Namespaces can be implemented in three ways:
 native namespaces (PEP 420, since Python 3.3), pkg_resources style (with ``__init__.py`` files that call ``pkg_resources.declare_namespace``) and pkgutil style (with ``__init__.py`` files that call ``pkgutil.extend_path``).
 
 Native namespaces are the modern way to do it. They work better with pip and other modern tools.
-The pkg_resources style depends on setuptools and is considered deprecated: setuptools is scheduled to drop support for it at the end of 2025, removing its foundational ``pkg_resources`` module.
+The pkg_resources style depends on setuptools and is considered deprecated: setuptools 82 dropped support for it, removing its foundational ``pkg_resources`` module.
+``zc.buildout`` ships its own copy of ``pkg_resources`` (taken from setuptools 81, see ``src/zc/buildout/_vendor/README.rst``), so buildout itself, recipes and extensions can keep using it inside a buildout run with any setuptools version.
+Scripts generated for distributions that use pkg_resources-style namespaces still need a real ``pkg_resources`` at script run time, so buildout keeps adding ``setuptools < 82`` to their working set unless you pin setuptools yourself.
 
 Problems start when you have multiple packages in the same namespace, that use different implementations.
 But it depends on what you use to install the packages.

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,8 @@ native namespaces (PEP 420, since Python 3.3), pkg_resources style (with ``__ini
 Native namespaces are the modern way to do it. They work better with pip and other modern tools.
 The pkg_resources style depends on setuptools and is considered deprecated: setuptools 82 dropped support for it, removing its foundational ``pkg_resources`` module.
 ``zc.buildout`` ships its own copy of ``pkg_resources`` (taken from setuptools 81, see ``src/zc/buildout/_vendor/README.rst``), so buildout itself, recipes and extensions can keep using it inside a buildout run with any setuptools version.
-Scripts generated for distributions that use pkg_resources-style namespaces still need a real ``pkg_resources`` at script run time, so buildout keeps adding ``setuptools < 82`` to their working set unless you pin setuptools yourself.
+Scripts generated for distributions that use pkg_resources-style namespaces still need a real ``pkg_resources`` at script run time, so buildout prefers adding ``setuptools < 82`` to their working set (unless you pin setuptools yourself).
+When no such setuptools version can be found or installed, buildout falls back to the available setuptools; if that is 82 or later, those scripts will not find ``pkg_resources`` at run time.
 
 Problems start when you have multiple packages in the same namespace, that use different implementations.
 But it depends on what you use to install the packages.

--- a/news/750.feature.rst
+++ b/news/750.feature.rst
@@ -1,0 +1,10 @@
+Lifted the ``setuptools < 82`` restriction: both the ``setuptools``
+requirement of ``zc.buildout`` and the automatic constraint applied to an
+unpinned ``setuptools`` during installs are gone, thanks to the vendored
+``pkg_resources`` copy.  Environments can now use setuptools 82 and later,
+including 83.0.0 which fixes the published vulnerability PYSEC-2026-3447
+(GHSA-h35f-9h28-mq5c).  Exception: distributions using
+pkg_resources-style namespace packages still get ``setuptools < 82``
+added to their working set (unless setuptools is pinned), because their
+generated scripts import ``pkg_resources`` at script run time.
+See `issue 750 <https://github.com/buildout/buildout/issues/750>`_.

--- a/news/750.feature.rst
+++ b/news/750.feature.rst
@@ -4,7 +4,9 @@ unpinned ``setuptools`` during installs are gone, thanks to the vendored
 ``pkg_resources`` copy.  Environments can now use setuptools 82 and later,
 including 83.0.0 which fixes the published vulnerability PYSEC-2026-3447
 (GHSA-h35f-9h28-mq5c).  Exception: distributions using
-pkg_resources-style namespace packages still get ``setuptools < 82``
+pkg_resources-style namespace packages preferably get ``setuptools < 82``
 added to their working set (unless setuptools is pinned), because their
-generated scripts import ``pkg_resources`` at script run time.
+generated scripts import ``pkg_resources`` at script run time.  When no
+such setuptools version is available, buildout falls back to the
+installed one.
 See `issue 750 <https://github.com/buildout/buildout/issues/750>`_.

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     package_dir = {'': 'src'},
     python_requires = '>=3.9',
     install_requires = [
-        'setuptools>=61.0.0,<82',
+        'setuptools>=61.0.0',
         'packaging>=23.2',
         'pip',
         # platformdirs is used by the vendored pkg_resources copy, see

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -810,6 +810,14 @@ class Installer(object):
             requirement = self._constrain(
                 pkg_resources.Requirement.parse('setuptools')
                 )
+            if not requirement.specs:
+                # The user did not pin setuptools.  Scripts using
+                # pkg_resources-style namespace packages run
+                # `import pkg_resources` at script run time, outside the
+                # buildout process where the copy vendored by zc.buildout
+                # is not importable, so they need a setuptools version
+                # that still ships pkg_resources (it was removed in 82).
+                requirement = _constrained_requirement('<82', requirement)
             if ws.find(requirement) is None:
                 self._get_dist(requirement, ws)
 
@@ -824,19 +832,6 @@ class Installer(object):
             except IncompatibleConstraintError:
                 logger.info(self._version_conflict_information(canonical_name))
                 raise
-        elif requirement.project_name == "setuptools":
-            # Restrict setuptools to less than 82 if it is not pinned.
-            # Especially when zc.buildout checks if it should upgrade itself
-            # or setuptools, under some circumstances this could lead to a
-            # too new setuptools version getting installed.
-            # See https://github.com/buildout/buildout/issues/744
-            try:
-                requirement = _constrained_requirement('<82',
-                                                       requirement)
-            except IncompatibleConstraintError:
-                logger.info(self._version_conflict_information(canonical_name))
-                raise
-
         return requirement
 
     def install(self, specs, working_set=None):

--- a/src/zc/buildout/easy_install.py
+++ b/src/zc/buildout/easy_install.py
@@ -815,9 +815,25 @@ class Installer(object):
                 # pkg_resources-style namespace packages run
                 # `import pkg_resources` at script run time, outside the
                 # buildout process where the copy vendored by zc.buildout
-                # is not importable, so they need a setuptools version
-                # that still ships pkg_resources (it was removed in 82).
-                requirement = _constrained_requirement('<82', requirement)
+                # is not importable, so prefer a setuptools version that
+                # still ships pkg_resources (it was removed in 82).
+                preferred = _constrained_requirement('<82', requirement)
+                if ws.find(preferred) is not None:
+                    return
+                try:
+                    self._get_dist(preferred, ws)
+                    return
+                except zc.buildout.UserError:
+                    # No setuptools < 82 available, for example offline
+                    # with only a newer setuptools installed.  Fall back
+                    # to any setuptools version: better a working set
+                    # with a pkg_resources-less setuptools than an
+                    # error.  Buildout already warns loudly about
+                    # old-style namespace packages elsewhere.
+                    logger.debug(
+                        "Could not get setuptools<82 (the last version "
+                        "that ships pkg_resources) for %s; falling back "
+                        "to any setuptools version.", dist)
             if ws.find(requirement) is None:
                 self._get_dist(requirement, ws)
 

--- a/src/zc/buildout/testing.py
+++ b/src/zc/buildout/testing.py
@@ -612,7 +612,10 @@ normalize_exception_type_for_python_2_and_3 = (
 normalize_open_in_generated_script = (
     re.compile(r"open\(__file__, 'U'\)"), 'open(__file__)')
 
-not_found = (re.compile(r'Not found: [^\n]+/(\w|\.|-)+/\r?\n'), '')
+# Remove the complete line: a partial match would leave the line prefix
+# (e.g. a "root: " logging prefix) glued to the following line, where a
+# later normalizer like ignore_root_logger could then eat that line too.
+not_found = (re.compile(r'.*Not found: [^\n]+/(\w|\.|-)+/\r?\n'), '')
 
 easyinstall_deprecated = (re.compile(r'.*EasyInstallDeprecationWarning.*\n'),'')
 setuptools_deprecated = (re.compile(r'.*SetuptoolsDeprecationWarning.*\n'),'')

--- a/src/zc/buildout/tests/test_unit.py
+++ b/src/zc/buildout/tests/test_unit.py
@@ -201,3 +201,46 @@ class TestVendoredPkgResources(unittest.TestCase):
         self.assertEqual(
             list(yield_lines(['foo\nbar', 'baz', 'bing\n\n\n'])),
             ['foo', 'bar', 'baz', 'bing'])
+
+
+class TestSetuptoolsConstraint(unittest.TestCase):
+    """Tests for how an unpinned setuptools requirement is constrained.
+
+    Since zc.buildout vendors its own pkg_resources copy, an unpinned
+    setuptools is no longer restricted for regular installs.  Only
+    distributions with pkg_resources-style namespace packages still get
+    setuptools<82 (the last version shipping pkg_resources) added to
+    their working set, because their scripts import pkg_resources at
+    script run time.  See https://github.com/buildout/buildout/issues/750
+    """
+
+    def test_constrain_leaves_unpinned_setuptools_alone(self):
+        import pkg_resources
+
+        from zc.buildout.easy_install import Installer
+        installer = Installer()
+        requirement = installer._constrain(
+            pkg_resources.Requirement.parse('setuptools'))
+        self.assertEqual(list(requirement.specs), [])
+
+    def test_constrain_applies_user_pin_to_setuptools(self):
+        import pkg_resources
+
+        from zc.buildout.easy_install import Installer
+        installer = Installer(versions={'setuptools': '81.0.0'})
+        requirement = installer._constrain(
+            pkg_resources.Requirement.parse('setuptools'))
+        self.assertEqual(str(requirement), 'setuptools==81.0.0')
+
+    def test_namespace_dists_get_setuptools_below_82(self):
+        # The building block used by Installer._maybe_add_setuptools when
+        # the user did not pin setuptools.
+        import pkg_resources
+
+        from zc.buildout.easy_install import _constrained_requirement
+        requirement = _constrained_requirement(
+            '<82', pkg_resources.Requirement.parse('setuptools'))
+        self.assertEqual(str(requirement), 'setuptools<82')
+        self.assertIn('81.0.0', requirement)
+        self.assertNotIn('82.0.0', requirement)
+        self.assertNotIn('83.0.0', requirement)


### PR DESCRIPTION
Builds on #751 (vendoring `pkg_resources`). With buildout carrying its own copy, setuptools no longer needs to provide it:

- Drop the `<82` upper bound from the `setuptools` requirement in `setup.py`.
- Drop the automatic `<82` constraint applied to an unpinned `setuptools` during installs (introduced for #744 — its motivation was protecting buildout's own `pkg_resources` import during self-upgrades, now covered by the vendored copy).
- **Exception:** distributions using pkg_resources-style namespace packages still get `setuptools<82` added to their working set (unless setuptools is pinned), because their generated scripts run `import pkg_resources` at script run time, outside the buildout process where the vendored copy is not importable.
- CI: test setuptools 82.0.1 and 83.0.0 in the main matrix, add Python 3.9 + 82.0.1 (the newest setuptools supporting 3.9) and 3.14 + 83.0.0 rows, and run the Windows and Mac jobs with 83.0.0 so script generation (`cli.exe`) is exercised with a setuptools that no longer ships `pkg_resources`.

setuptools 83.0.0 fixes PYSEC-2026-3447 (GHSA-h35f-9h28-mq5c); environments on Python ≥ 3.10 can now install it alongside buildout. On Python 3.9 the ceiling remains setuptools 82.0.1, per setuptools' own support policy.

Fixes #750

— _PR created by Claude_
