### PR TITLE
Upgrade packaging in the script-generation sandboxes.

### DIFF
--- a/.github/workflows/Makefile-scripts
+++ b/.github/workflows/Makefile-scripts
@@ -1,7 +1,11 @@
+# Upgrade packaging: the version bundled by virtualenv can be too old
+# for the requirements of the packages installed in the test buildout
+# (e.g. twine 7 needs packaging>=26.1), and buildout cannot upgrade a
+# distribution that is already active in the sandbox.
 sandbox/bin/python:
 	pip install virtualenv
 	virtualenv sandbox
-	sandbox/bin/python -mpip install 'setuptools<80'
+	sandbox/bin/python -mpip install 'setuptools<80' --upgrade packaging
 
 sandbox/bin/buildout: sandbox/bin/python
 	sandbox/bin/python setup.py develop

--- a/.github/workflows/Makefile-scripts-setuptools-head
+++ b/.github/workflows/Makefile-scripts-setuptools-head
@@ -1,7 +1,12 @@
+# Upgrade packaging: the version bundled by virtualenv can be too old
+# for the requirements of the packages installed in the test buildout
+# (e.g. twine 7 needs packaging>=26.1), and buildout cannot upgrade a
+# distribution that is already active in the sandbox.
 sandbox/bin/python:
 	pip install virtualenv
 	virtualenv --no-setuptools sandbox
 	sandbox/bin/pip install -e "git+https://github.com/pypa/setuptools.git#egg=setuptools"
+	sandbox/bin/pip install --upgrade packaging
 
 sandbox/bin/buildout: sandbox/bin/python
 	sandbox/bin/python setup.py develop


### PR DESCRIPTION
I have created a maintenance branch 5.x, so on master we can make some backwards incompatible changes when needed.

On the new 5.x we then need one commit from PR #751, which I cherry-pick here.  That commit fixes a test failure on current master, so also on the new 5.x.  Yesterday I triggered a test run on master and there is indeed a [failure in the tests for generating scripts](https://github.com/buildout/buildout/actions/runs/31111504765/job/92664781891).  This PR fixes it.

Here is the commit message from @icemac 

twine 7.0.0 (released 2026-07-27) requires packaging>=26.1, but the sandbox virtualenv comes with the packaging version bundled by virtualenv (24.2) and buildout cannot upgrade a distribution that is already active in the sandbox.  This makes the generate-scripts job fail for the zest.releaser package on master as well (master last ran CI on 2026-06-03, before the twine release).