### PR TITLE
Prepare for zc.buildout 6.0.0 and zc.recipe.egg 5.0.0

### DIFF
--- a/zc.recipe.egg_/CHANGES.rst
+++ b/zc.recipe.egg_/CHANGES.rst
@@ -1,7 +1,7 @@
 Change History
 **************
 
-4.0.1 (unreleased)
+5.0.0 (unreleased)
 ==================
 
 - Nothing changed yet.

--- a/zc.recipe.egg_/setup.py
+++ b/zc.recipe.egg_/setup.py
@@ -14,7 +14,7 @@
 """Setup for zc.recipe.egg package
 """
 
-version = '4.0.1.dev0'
+version = '5.0.0.dev0'
 
 import os
 from setuptools import setup


### PR DESCRIPTION
Base of the branch stack that implements the version-floor proposal in #755.

The next releases from master raise the minimum supported Python, setuptools
and pip versions, so both packages get a major version bump:

* `zc.buildout` 5.2.1.dev0 → 6.0.0.dev0
* `zc.recipe.egg` 4.0.1.dev0 → 5.0.0.dev0 (it also loses Python 3.9, and its
  4.0.0 entry is the one that introduced the 3.9 floor)

## The rest of the stack

Each PR branches off the previous one:

1. **this PR** — version bump
2. #759 — require setuptools 75.8.2
3. #760 — require pip 25.0
4. #761 — require Python 3.10

setuptools comes before Python on purpose: moving the primary CI Python to
3.13 while the matrix still contains setuptools 63/65/69 would break CI,
because those setuptools releases predate Python 3.13.

— _Comment created by Claude_
