### PR TITLE
Require pip 25.0 as a minimum

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -85,7 +85,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ["3.10"]
-        pip-version: ["21.3.1", "22.3.1", "23.3.2", "24.3.1", "25.3", "26.1.2"]
+        # Only the latest release of each year, so we do not go hunting for
+        # bugs that pip fixed later in the same year.
+        pip-version: ["25.3", "26.1.2"]
         setuptools-version: ["75.8.2", "83.0.0"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/news/755.breaking.rst
+++ b/news/755.breaking.rst
@@ -7,4 +7,8 @@ Consequently the following patches are gone from ``zc.buildout.patches``:
 ``patch_interpret_distro_name`` (only needed below setuptools 70, and
 already inoperative because it imported a module that had been renamed)
 and ``patch_Distribution`` (disabled for years).
+
+Require ``pip >= 25.0``, and test only against the latest pip release of
+each year.
+
 See `issue 755 <https://github.com/buildout/buildout/issues/755>`_.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     install_requires = [
         'setuptools>=75.8.2',
         'packaging>=23.2',
-        'pip',
+        'pip>=25.0',
         # platformdirs is used by the vendored pkg_resources copy, see
         # src/zc/buildout/_vendor/README.rst
         'platformdirs',


### PR DESCRIPTION
Part 3 of the branch stack for #755. Branches off #759.

* `setup.py`: `pip` → `pip>=25.0`. The floor goes into `install_requires` and
  not just the test matrix, so it is actually enforced.
* Reduce the pip test matrix from
  `["21.3.1", "22.3.1", "23.3.2", "24.3.1", "25.3", "26.1.2"]` to
  `["25.3", "26.1.2"]` — the latest release of each year, which is the
  strategy already described in #755: testing older releases within a year
  mostly finds bugs that pip fixed later that same year.

## What I left alone

The pip-related fallbacks in `patches.py` (`IndexContent`/`HTMLPage`, the
three-way `IndexContent` constructor, `use_deprecated_html5lib`) and
`no_python_version_warning` in `easy_install.py` are `try`/`except ImportError`
capability probes, not version comparisons. Removing them is a behavioural
risk out of proportion to the payoff, so they are unchanged here. Happy to do
it as a focused follow-up if you want them gone.

— _Comment created by Claude_