### PR TITLE
Update tests for generating scripts.

### DIFF
--- a/.github/workflows/Makefile-scripts
+++ b/.github/workflows/Makefile-scripts
@@ -3,10 +3,8 @@
 # (e.g. twine 7 needs packaging>=26.1), and buildout cannot upgrade a
 # distribution that is already active in the sandbox.
 sandbox/bin/python:
-	pip install virtualenv
-	virtualenv sandbox
-	sandbox/bin/python -mpip install 'setuptools<80' --upgrade packaging
+	python -mvenv sandbox
+	sandbox/bin/python -mpip install 'setuptools' --upgrade packaging
 
 sandbox/bin/buildout: sandbox/bin/python
-	sandbox/bin/python setup.py develop
-
+	sandbox/bin/python -mpip install -e .

--- a/.github/workflows/Makefile-scripts-setuptools-head
+++ b/.github/workflows/Makefile-scripts-setuptools-head
@@ -3,11 +3,10 @@
 # (e.g. twine 7 needs packaging>=26.1), and buildout cannot upgrade a
 # distribution that is already active in the sandbox.
 sandbox/bin/python:
-	pip install virtualenv
-	virtualenv --no-setuptools sandbox
-	sandbox/bin/pip install -e "git+https://github.com/pypa/setuptools.git#egg=setuptools"
+	python -mvenv sandbox
+	sandbox/bin/python -mpip install -e "git+https://github.com/pypa/setuptools.git#egg=setuptools"
 	sandbox/bin/pip install --upgrade packaging
 
 sandbox/bin/buildout: sandbox/bin/python
 	sandbox/bin/python setup.py develop
-
+	sandbox/bin/python -mpip install -e .

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -188,7 +188,9 @@ jobs:
       run: |
         sandbox/bin/buildout -v -c .github/workflows/scripts-${PYTHON_VERSION}.cfg annotate buildout
         sandbox/bin/buildout -c .github/workflows/scripts-${PYTHON_VERSION}.cfg
+    - name: Check downloads
+      run: |
+        ls -al sandbox/downloads/dist
     - name: Check eggs
       run: |
-        ls -al sandbox/eggs
-        ls -al sandbox/downloads/dist
+        ls -al sandbox/eggs/v5

--- a/.github/workflows/scripts-setuptools-head.yml
+++ b/.github/workflows/scripts-setuptools-head.yml
@@ -32,8 +32,9 @@ jobs:
       run: |
         sandbox/bin/buildout -v -c .github/workflows/scripts-${PYTHON_VERSION}.cfg annotate buildout
         sandbox/bin/buildout -c .github/workflows/scripts-${PYTHON_VERSION}.cfg
+    - name: Check downloads
+      run: |
+        ls -al sandbox/downloads/dist
     - name: Check eggs
       run: |
-        ls -al sandbox/eggs
-        ls -al sandbox/downloads/dist
-
+        ls -al sandbox/eggs/v5

--- a/.github/workflows/scripts.cfg
+++ b/.github/workflows/scripts.cfg
@@ -8,7 +8,10 @@ parts = test
 sandbox = ${buildout:directory}/../../sandbox
 eggs-directory = ${buildout:sandbox}/eggs
 download-cache = ${buildout:sandbox}/downloads
+# abi-tag-eggs is false, so we can just check the eggs/v5 dir:
 abi-tag-eggs = false
+# prefer-final is false so we can pull in alpha versions of zc.recipe.egg:
+prefer-final = false
 
 [test]
 recipe = zc.recipe.egg


### PR DESCRIPTION
* The `Makefile` was using `setuptools<80`.  Removed the upper version bound.
* Don't use `virtualenv`, but the built-in `venv` module.
* Don't call `python setup.py develop`, but `python -mpip install -e`.
* We were trying to list the installed eggs, but this only showed the existence of a `v5` directory.  Show the contents of that directory instead.

<strike>This contains a temporary commit to only run the scripts and not the other tests.  I will remove that if this passes.</strike>  Update: tests were green, also the ones with setuptools HEAD that I manually triggered, so I have removed this temporary commit.