### PR TITLE
Test on Python 3.15 and setuptools 84.0.0.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,7 +21,7 @@ jobs:
         # 80.3), 81.0.0 is the last one shipping pkg_resources and
         # 82.0.1 the first one without it (buildout uses its own
         # vendored copy on all versions).
-        setuptools-version: ["75.8.2", "79.0.1", "80.2.0", "80.10.2", "81.0.0", "82.0.1", "83.0.0"]
+        setuptools-version: ["75.8.2", "79.0.1", "80.2.0", "80.10.2", "81.0.0", "82.0.1", "83.0.0", "84.0.0"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6.0.2
@@ -51,7 +51,7 @@ jobs:
         # Skip "3.13" because it is already checked above.
         # The setuptools matrix above covers the version range, so here we
         # only use the newest setuptools, which supports every Python we test.
-        python-version: ["3.10", "3.11", "3.12", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.14", "3.15"]
         setuptools-version: ["83.0.0"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 .coverage
 .coverage.*
 .vscode/
+uv.lock

--- a/news/+155d37af.feature.rst
+++ b/news/+155d37af.feature.rst
@@ -1,0 +1,1 @@
+Test on Python 3.15 and setuptools 84.0.0.  [maurits]

--- a/prepare.sh
+++ b/prepare.sh
@@ -63,7 +63,15 @@ case "$OSTYPE" in
 esac
 echo
 echo "Python version:"
-$PYTHON --version
+if test "$USE_UV"; then
+    # This looks weird with all the double dashes and pythons, so let's explain.
+    # Call `uv run` with an option like `--python 3.15`.
+    # Then use `--` to signal an end to the command line options.
+    # Then follows the command we want uv to run: `python --version`.
+    uv run --python $PYTHON_VERSION -- python --version
+else
+    $PYTHON --version
+fi
 
 echo
 echo "Creating virtual environment in $VENV"

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
        'Programming Language :: Python :: 3.12',
        'Programming Language :: Python :: 3.13',
        'Programming Language :: Python :: 3.14',
+       'Programming Language :: Python :: 3.15',
        'Topic :: Software Development :: Build Tools',
        'Topic :: Software Development :: Libraries :: Python Modules',
        ],

--- a/zc.recipe.egg_/CHANGES.rst
+++ b/zc.recipe.egg_/CHANGES.rst
@@ -4,7 +4,7 @@ Change History
 6.0.0a2 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Add support for Python 3.15.
 
 
 6.0.0a1 (2026-08-14)

--- a/zc.recipe.egg_/setup.py
+++ b/zc.recipe.egg_/setup.py
@@ -62,6 +62,7 @@ setup(
        'Programming Language :: Python :: 3.12',
        'Programming Language :: Python :: 3.13',
        'Programming Language :: Python :: 3.14',
+       'Programming Language :: Python :: 3.15',
        'Topic :: Software Development :: Build Tools',
        'Topic :: Software Development :: Libraries :: Python Modules',
        ],


### PR DESCRIPTION
And fix using the `USE_UV` environment variable.
I did not have Python 3.15 installed yet, so wanted to use `uv`, but this failed. Now this works:

```
export USE_UV=1
export PYTHON_VERSION=3.15
make test
```