### PR TITLE
Add simple but real test projects.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -36,6 +36,7 @@ jobs:
 
   setuptools:
     name: setuptools ${{ matrix.setuptools-version}}
+    needs: projects
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,6 +7,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  projects:
+    name: projects
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        python-version: ["3.14"]
+        setuptools-version: ["84.0.0"]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v6.0.2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip' # caching pip dependencies
+    - name: Run project buildouts
+      env:
+        # When you install packages, you see far too many setuptools warnings.
+        # They drown out useful output, so ignore all warnings.
+        PYTHONWARNINGS: ignore
+        PYTHON_VERSION: ${{matrix.python-version}}
+        # PIP_VERSION: ${{matrix.pip-version}}
+        SETUPTOOLS_VERSION: ${{matrix.setuptools-version}}
+      run: make test-projects
+
   setuptools:
     name: setuptools ${{ matrix.setuptools-version}}
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,11 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v6.0.2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.2.0
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v10.0.0
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip' # caching pip dependencies
     - name: Run project buildouts
       env:
         # When you install packages, you see far too many setuptools warnings.

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,6 +31,7 @@ jobs:
         PYTHON_VERSION: ${{matrix.python-version}}
         # PIP_VERSION: ${{matrix.pip-version}}
         SETUPTOOLS_VERSION: ${{matrix.setuptools-version}}
+        USE_UV: true
       run: make test-projects
 
   setuptools:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,6 @@ recursive-include src/zc *.rst
 prune doc
 prune old-tutorial
 prune zc.recipe.egg_
-recursive-exclude news *
 exclude .deepsource.toml
-exclude news
+prune news
+prune projects

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ test-recipe: bin/test
 test-small: bin/test
 	PYTHONWARNINGS=ignore bin/test -pvc -t buildout.txt
 
+test-projects: bin/buildout
+	$(MAKE) -C "./projects/"
+
 help:
 	./prepare.sh --help
 

--- a/news/+1159ab01.tests.rst
+++ b/news/+1159ab01.tests.rst
@@ -1,0 +1,1 @@
+Add simple but real test projects.  [maurits]

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -1,5 +1,5 @@
-.PHONY: all clean simple namespaces downloads final pips
-all: simple namespaces final
+.PHONY: all clean simple namespaces downloads final mixed pips
+all: simple namespaces final mixed
 
 clean:
 	# Remove files and directories that are ignored by git.
@@ -37,6 +37,12 @@ final: ../bin/buildout downloads
 	buildouts/final/bin/setuptoolsdemo
 	buildouts/final/bin/ns_hat
 	buildouts/final/bin/ns_tools
+
+mixed: ../bin/buildout downloads
+	cd buildouts/mixed && ../../../bin/buildout
+	@echo "Buildout has finished. Running the scripts."
+	buildouts/mixed/bin/ns_hat
+	buildouts/mixed/bin/ns_tools
 
 # For comparing with pip/uv:
 pips:

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all pips
-all: simple
+all: simple namespaces
 
 simple: ../bin/buildout
 	cd buildouts/simple && ../../../bin/buildout
@@ -7,7 +7,15 @@ simple: ../bin/buildout
 	buildouts/simple/bin/hatchdemo
 	buildouts/simple/bin/setuptoolsdemo
 
+namespaces: ../bin/buildout
+	cd buildouts/namespaces && ../../../bin/buildout
+	@echo "Buildout has finished. Running the scripts."
+	buildouts/namespaces/bin/ns_hat
+	buildouts/namespaces/bin/ns_tools
+
 # For comparing with pip/uv:
 pips:
 	uv run --with-requirements requirements/simple.txt hatchdemo
 	uv run --with-requirements requirements/simple.txt setuptoolsdemo
+	uv run --with-requirements requirements/namespaces.txt ns_hat
+	uv run --with-requirements requirements/namespaces.txt ns_tools

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -5,7 +5,9 @@ simple: ../bin/buildout
 	cd buildouts/simple && ../../../bin/buildout
 	@echo "Buildout has finished. Running the scripts."
 	buildouts/simple/bin/hatchdemo
+	buildouts/simple/bin/setuptoolsdemo
 
 # For comparing with pip/uv:
 pips:
 	uv run --with-requirements requirements/simple.txt hatchdemo
+	uv run --with-requirements requirements/simple.txt setuptoolsdemo

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -1,5 +1,9 @@
-.PHONY: all pips
-all: simple namespaces
+.PHONY: all clean simple namespaces downloads final pips
+all: simple namespaces final
+
+clean:
+	# Remove files and directories that are ignored by git.
+	git clean -dfX
 
 simple: ../bin/buildout
 	cd buildouts/simple && ../../../bin/buildout
@@ -13,9 +17,34 @@ namespaces: ../bin/buildout
 	buildouts/namespaces/bin/ns_hat
 	buildouts/namespaces/bin/ns_tools
 
+DOWNLOADS_SENTINEL=downloads/.sentinel
+$(DOWNLOADS_SENTINEL): packages/hatchdemo/pyproject.toml packages/setuptoolsdemo/pyproject.toml packages/ns.hat/pyproject.toml packages/ns.tools/pyproject.toml
+	rm -rf downloads/dist
+	mkdir -p downloads/dist
+	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/hatchdemo
+	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/setuptoolsdemo
+	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/ns.hat
+	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/ns.tools
+	@touch $(DOWNLOADS_SENTINEL)
+
+downloads: $(DOWNLOADS_SENTINEL)
+	ls -l downloads/dist
+
+final: ../bin/buildout downloads
+	cd buildouts/final && ../../../bin/buildout
+	@echo "Buildout has finished. Running the scripts."
+	buildouts/final/bin/hatchdemo
+	buildouts/final/bin/setuptoolsdemo
+	buildouts/final/bin/ns_hat
+	buildouts/final/bin/ns_tools
+
 # For comparing with pip/uv:
 pips:
 	uv run --with-requirements requirements/simple.txt hatchdemo
 	uv run --with-requirements requirements/simple.txt setuptoolsdemo
 	uv run --with-requirements requirements/namespaces.txt ns_hat
 	uv run --with-requirements requirements/namespaces.txt ns_tools
+	uv run --with-requirements requirements/final.txt hatchdemo
+	uv run --with-requirements requirements/final.txt setuptoolsdemo
+	uv run --with-requirements requirements/final.txt ns_hat
+	uv run --with-requirements requirements/final.txt ns_tools

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -14,6 +14,7 @@ simple: ../bin/buildout
 namespaces: ../bin/buildout
 	cd buildouts/namespaces && ../../../bin/buildout
 	@echo "Buildout has finished. Running the scripts."
+	buildouts/namespaces/bin/ns_ancient
 	buildouts/namespaces/bin/ns_hat
 	buildouts/namespaces/bin/ns_tools
 
@@ -23,6 +24,7 @@ $(DOWNLOADS_SENTINEL): packages/hatchdemo/pyproject.toml packages/setuptoolsdemo
 	mkdir -p downloads/dist
 	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/hatchdemo
 	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/setuptoolsdemo
+	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/ns.ancient
 	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/ns.hat
 	uvx --from build pyproject-build --wheel --outdir downloads/dist packages/ns.tools
 	@touch $(DOWNLOADS_SENTINEL)
@@ -35,12 +37,14 @@ final: ../bin/buildout downloads
 	@echo "Buildout has finished. Running the scripts."
 	buildouts/final/bin/hatchdemo
 	buildouts/final/bin/setuptoolsdemo
+	buildouts/final/bin/ns_ancient
 	buildouts/final/bin/ns_hat
 	buildouts/final/bin/ns_tools
 
 mixed: ../bin/buildout downloads
 	cd buildouts/mixed && ../../../bin/buildout
 	@echo "Buildout has finished. Running the scripts."
+	buildouts/mixed/bin/ns_ancient
 	buildouts/mixed/bin/ns_hat
 	buildouts/mixed/bin/ns_tools
 
@@ -48,9 +52,14 @@ mixed: ../bin/buildout downloads
 pips:
 	uv run --with-requirements requirements/simple.txt hatchdemo
 	uv run --with-requirements requirements/simple.txt setuptoolsdemo
+	uv run --with-requirements requirements/namespaces.txt ns_ancient
 	uv run --with-requirements requirements/namespaces.txt ns_hat
 	uv run --with-requirements requirements/namespaces.txt ns_tools
 	uv run --with-requirements requirements/final.txt hatchdemo
 	uv run --with-requirements requirements/final.txt setuptoolsdemo
+	uv run --with-requirements requirements/final.txt ns_ancient
 	uv run --with-requirements requirements/final.txt ns_hat
 	uv run --with-requirements requirements/final.txt ns_tools
+	uv run --with-requirements requirements/mixed.txt ns_ancient
+	uv run --with-requirements requirements/mixed.txt ns_hat
+	uv run --with-requirements requirements/mixed.txt ns_tools

--- a/projects/Makefile
+++ b/projects/Makefile
@@ -1,0 +1,11 @@
+.PHONY: all pips
+all: simple
+
+simple: ../bin/buildout
+	cd buildouts/simple && ../../../bin/buildout
+	@echo "Buildout has finished. Running the scripts."
+	buildouts/simple/bin/hatchdemo
+
+# For comparing with pip/uv:
+pips:
+	uv run --with-requirements requirements/simple.txt hatchdemo

--- a/projects/README-projects.md
+++ b/projects/README-projects.md
@@ -47,6 +47,7 @@ Each sub directory has a `buildout.cfg` that does the following:
 
 * `simple`: `hatchdemo` and `setuptoolsdemo` packages
 * `namespaces`: `ns.hat` and `ns.tools` packages
+* `final`: all packages in final form, installed from a wheel
 
 
 ## Packages
@@ -104,9 +105,3 @@ If any scripts don't work there, there is not much point in trying to get this t
 ```
 make pips
 ```
-
-## Ideas
-
-* Run `pyproject-build` on the packages and put those in a directory that I add to `find-links` or use as `index`.
-  Then we can try combinations of final and development packages.
-  This is also useful to check that our packages are actually valid.

--- a/projects/README-projects.md
+++ b/projects/README-projects.md
@@ -1,0 +1,108 @@
+# Test projects
+
+## Introduction
+
+Within this `projects` directory are two sub directories: `packages` and `buildouts`.
+For now, each contains only one package or buildout directory, but I want that to grow.
+I want to use this to really test some common scenarios in a debuggable way.
+Meaning: no doctests, simply run `bin/buildout` with a config, so you can add a breakpoint.
+
+
+## Usage:
+
+Within the main directory, so one level up, you can run:
+
+```
+make test-projects
+```
+
+Within the `projects` directory, you can just run all projects:
+
+```
+make
+```
+
+Or run a single one:
+
+```
+make simple
+```
+
+In the `Makefile` we go to one of the buildout directories.
+Then we run `bin/buildout` from the top-level directory.
+
+
+## Buildouts
+
+Each sub directory has a `buildout.cfg` that does the following:
+
+* `develop` one or more of our packages.
+* Create a `bin/testscript` that has all those packages.
+  With this you can check if you can import them.
+* Automatically create the console scripts that each package defines.
+  With this you can check that entry points are found correctly and the script works.
+
+
+### Current buildouts
+
+* `simple`: `hatchdemo`
+
+
+## Packages
+
+Each package registers a console script so you can check that the package can find itself.
+I want to focus on modern packaging methods:
+
+* No `setup.py`, just `pyproject.toml`.
+* Everything in a `src` directory.
+* Not just `setuptools`, also `hatchling` or other projects.
+* Only native namespaces, when used.
+
+
+### Current packages:
+
+* `hatchdemo`: basic package using `hatchling`
+
+
+### New package
+
+To create a new package, you can do:
+
+```
+uvx hatch new <name>
+```
+
+I don't yet know if that can handle namespaces.
+If you want a `setuptools` package, you can just do the same, and edit `pyproject.toml`.
+
+Afterwards, register a console script in `pyroject.toml`:
+
+```
+[project.scripts]
+hatchdemo = "hatchdemo:main"
+```
+
+And add a function in the `__init__.py` of the package, printing the name of the package:
+
+```
+def main():
+    print("hatchdemo main script")
+```
+
+Or you copy an existing demo package and go from there.
+
+
+## Compare with pip/uv
+
+Each buildout config should have a mirror in a requirements file in the `requirements` directory.
+If any scripts don't work there, there is not much point in trying to get this to work in Buildout.
+
+```
+make pips
+```
+
+## Ideas
+
+* Run `pyproject-build` on the packages and put those in a directory that I add to `find-links` or use as `index`.
+  Then we can try combinations of final and development packages.
+  This is also useful to check that our packages are actually valid.

--- a/projects/README-projects.md
+++ b/projects/README-projects.md
@@ -46,8 +46,12 @@ Each sub directory has a `buildout.cfg` that does the following:
 ### Current buildouts
 
 * `simple`: `hatchdemo` and `setuptoolsdemo` packages
-* `namespaces`: `ns.hat` and `ns.tools` packages
+* `namespaces`: `ns.ancient`, `ns.hat` and `ns.tools` packages
 * `final`: all packages in final form, installed from a wheel
+* `mixed`: all namespace packages, some in development, some final
+
+The buildout that I most expect to fail, is the mixed one.
+But so far it works.
 
 
 ## Packages
@@ -67,6 +71,7 @@ I want to focus on modern packaging methods:
 * `setuptoolsdemo`: basic package using `setuptools`
 * `ns.hat`: namespace package using `hatchling`
 * `ns.tools`: namespace package using `setuptools`
+* `ns.ancient`: namespace package using `setuptools`, and still a `setup.py`
 
 
 ### New package

--- a/projects/README-projects.md
+++ b/projects/README-projects.md
@@ -2,8 +2,7 @@
 
 ## Introduction
 
-Within this `projects` directory are two sub directories: `packages` and `buildouts`.
-For now, each contains only one package or buildout directory, but I want that to grow.
+Within this `projects` directory are three directories: `packages`, `buildouts`, and `requirements`.
 I want to use this to really test some common scenarios in a debuggable way.
 Meaning: no doctests, simply run `bin/buildout` with a config, so you can add a breakpoint.
 
@@ -16,7 +15,7 @@ Within the main directory, so one level up, you can run:
 make test-projects
 ```
 
-Within the `projects` directory, you can just run all projects:
+This runs `make` within the `projects` directory, so you can also go to the `projects` directory yourself and run make:
 
 ```
 make
@@ -28,26 +27,34 @@ Or run a single one:
 make simple
 ```
 
-In the `Makefile` we go to one of the buildout directories.
-Then we run `bin/buildout` from the top-level directory.
+In most of the `Makefile` targets we go to one of the buildout directories.
+There we run `bin/buildout` from the top-level directory.
 
 
 ## Buildouts
 
 Each sub directory has a `buildout.cfg` that does the following:
 
-* `develop` one or more of our packages.
+* `develop` zero, one, or more of our packages.
 * Create a `bin/testscript` that has all those packages.
   With this you can check if you can import them.
 * Automatically create the console scripts that each package defines.
   With this you can check that entry points are found correctly and the script works.
 
+### Shared config
+
+The buildouts extend `projects/buildout/shared.cfg` which has the common config.
+Among others, it defines a download cache in `projects/downloads/dist`, and an eggs cache in `projects/eggs`.
+
+### Downloads
+
+The `make downloads` target creates final wheels of all our packages, and puts them in `projects/downloads/dist`, so buildouts can find them.
 
 ### Current buildouts
 
 * `simple`: `hatchdemo` and `setuptoolsdemo` packages
 * `namespaces`: `ns.ancient`, `ns.hat` and `ns.tools` packages
-* `final`: all packages in final form, installed from a wheel
+* `final`: all packages in final form, installed from a wheel in the downloads cache
 * `mixed`: all namespace packages, some in development, some final
 
 The buildout that I most expect to fail, is the mixed one.
@@ -76,27 +83,29 @@ I want to focus on modern packaging methods:
 
 ### New package
 
-To create a new package, you can do:
+I created the basis of the `hatchdemo` package with this command:
 
 ```
-uvx hatch new <name>
+uvx hatch new hatchdemo
 ```
 
-I don't yet know if that can handle namespaces.
-If you want a `setuptools` package, you can just do the same, and edit `pyproject.toml`.
+So if you want to create a new package, you can use the same command.
+But copying and editing is likely easier.
+That is what I did for the other projects.
+I removed lots of metadata though, which we did not need.
 
-Afterwards, register a console script in `pyroject.toml`:
+If you create your own package by hand, make sure to register a console script in `pyroject.toml`:
 
 ```
 [project.scripts]
-hatchdemo = "hatchdemo:main"
+<script name> = "<package name>:main"
 ```
 
 And add a function in the `__init__.py` of the package, printing the name of the package:
 
 ```
 def main():
-    print("hatchdemo main script")
+    print("<package name> main script")
 ```
 
 Or you copy an existing demo package and go from there.
@@ -110,3 +119,5 @@ If any scripts don't work there, there is not much point in trying to get this t
 ```
 make pips
 ```
+
+Note: when you run `make` or `make all`, the `pips` target is not run, as we only want to know if our buildouts work.

--- a/projects/README-projects.md
+++ b/projects/README-projects.md
@@ -45,7 +45,8 @@ Each sub directory has a `buildout.cfg` that does the following:
 
 ### Current buildouts
 
-* `simple`: `hatchdemo`
+* `simple`: `hatchdemo` and `setuptoolsdemo` packages
+* `namespaces`: `ns.hat` and `ns.tools` packages
 
 
 ## Packages
@@ -62,6 +63,9 @@ I want to focus on modern packaging methods:
 ### Current packages:
 
 * `hatchdemo`: basic package using `hatchling`
+* `setuptoolsdemo`: basic package using `setuptools`
+* `ns.hat`: namespace package using `hatchling`
+* `ns.tools`: namespace package using `setuptools`
 
 
 ### New package

--- a/projects/buildouts/final/buildout.cfg
+++ b/projects/buildouts/final/buildout.cfg
@@ -1,0 +1,15 @@
+[buildout]
+index =
+download-cache = ../../downloads
+parts = testscript
+develop =
+newest = false
+
+[testscript]
+recipe = zc.recipe.egg
+interpreter = testscript
+eggs =
+    hatchdemo
+    setuptoolsdemo
+    ns.hat
+    ns.tools

--- a/projects/buildouts/final/buildout.cfg
+++ b/projects/buildouts/final/buildout.cfg
@@ -4,5 +4,6 @@ develop =
 testeggs =
     hatchdemo
     setuptoolsdemo
+    ns.ancient
     ns.hat
     ns.tools

--- a/projects/buildouts/final/buildout.cfg
+++ b/projects/buildouts/final/buildout.cfg
@@ -1,14 +1,7 @@
 [buildout]
-index =
-download-cache = ../../downloads
-parts = testscript
+extends = ../shared.cfg
 develop =
-newest = false
-
-[testscript]
-recipe = zc.recipe.egg
-interpreter = testscript
-eggs =
+testeggs =
     hatchdemo
     setuptoolsdemo
     ns.hat

--- a/projects/buildouts/mixed/buildout.cfg
+++ b/projects/buildouts/mixed/buildout.cfg
@@ -1,9 +1,11 @@
 [buildout]
 extends = ../shared.cfg
-# I want one namespace package in development, the other final.
+# I want at leasst one namespace package in development, and one final.
 develop =
+    ../../packages/ns.ancient
     ../../packages/ns.hat
 #    ../../packages/ns.tools
 testeggs =
+    ns.ancient
     ns.hat
     ns.tools

--- a/projects/buildouts/mixed/buildout.cfg
+++ b/projects/buildouts/mixed/buildout.cfg
@@ -1,8 +1,9 @@
 [buildout]
 extends = ../shared.cfg
+# I want one namespace package in development, the other final.
 develop =
     ../../packages/ns.hat
-    ../../packages/ns.tools
+#    ../../packages/ns.tools
 testeggs =
     ns.hat
     ns.tools

--- a/projects/buildouts/namespaces/buildout.cfg
+++ b/projects/buildouts/namespaces/buildout.cfg
@@ -1,8 +1,10 @@
 [buildout]
 extends = ../shared.cfg
 develop =
+    ../../packages/ns.ancient
     ../../packages/ns.hat
     ../../packages/ns.tools
 testeggs =
+    ns.ancient
     ns.hat
     ns.tools

--- a/projects/buildouts/namespaces/buildout.cfg
+++ b/projects/buildouts/namespaces/buildout.cfg
@@ -1,0 +1,14 @@
+[buildout]
+index =
+parts = testscript
+develop =
+    ../../packages/ns.hat
+    ../../packages/ns.tools
+newest = false
+
+[testscript]
+recipe = zc.recipe.egg
+interpreter = testscript
+eggs =
+    ns.hat
+    ns.tools

--- a/projects/buildouts/shared.cfg
+++ b/projects/buildouts/shared.cfg
@@ -1,0 +1,16 @@
+[buildout]
+# These paths are relative to the current buildout config.
+download-cache = ../downloads
+eggs-directory = ../eggs
+parts = testscript
+newest = false
+testeggs =
+
+[versions]
+zc.buildout =
+zc.recipe.egg = >= 6.0.0a1
+
+[testscript]
+recipe = zc.recipe.egg
+interpreter = testscript
+eggs = ${buildout:testeggs}

--- a/projects/buildouts/simple/buildout.cfg
+++ b/projects/buildouts/simple/buildout.cfg
@@ -1,14 +1,8 @@
 [buildout]
-index =
-parts = testscript
+extends = ../shared.cfg
 develop =
     ../../packages/hatchdemo
     ../../packages/setuptoolsdemo
-newest = false
-
-[testscript]
-recipe = zc.recipe.egg
-interpreter = testscript
-eggs =
+testeggs =
     hatchdemo
     setuptoolsdemo

--- a/projects/buildouts/simple/buildout.cfg
+++ b/projects/buildouts/simple/buildout.cfg
@@ -1,0 +1,12 @@
+[buildout]
+index =
+parts = testscript
+develop =
+    ../../packages/hatchdemo
+newest = false
+
+[testscript]
+recipe = zc.recipe.egg
+interpreter = testscript
+eggs =
+    hatchdemo

--- a/projects/buildouts/simple/buildout.cfg
+++ b/projects/buildouts/simple/buildout.cfg
@@ -3,6 +3,7 @@ index =
 parts = testscript
 develop =
     ../../packages/hatchdemo
+    ../../packages/setuptoolsdemo
 newest = false
 
 [testscript]
@@ -10,3 +11,4 @@ recipe = zc.recipe.egg
 interpreter = testscript
 eggs =
     hatchdemo
+    setuptoolsdemo

--- a/projects/packages/hatchdemo/LICENSE.txt
+++ b/projects/packages/hatchdemo/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026-present Maurits van Rees <maurits@vanrees.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/projects/packages/hatchdemo/README.md
+++ b/projects/packages/hatchdemo/README.md
@@ -1,0 +1,21 @@
+# hatchdemo
+
+[![PyPI - Version](https://img.shields.io/pypi/v/hatchdemo.svg)](https://pypi.org/project/hatchdemo)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/hatchdemo.svg)](https://pypi.org/project/hatchdemo)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install hatchdemo
+```
+
+## License
+
+`hatchdemo` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/projects/packages/hatchdemo/pyproject.toml
+++ b/projects/packages/hatchdemo/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hatchdemo"
+dynamic = ["version"]
+description = ''
+readme = "README.md"
+requires-python = ">=3.8"
+license = "MIT"
+keywords = []
+authors = [
+  { name = "Maurits van Rees", email = "maurits@vanrees.org" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://github.com/Maurits van Rees/hatchdemo#readme"
+Issues = "https://github.com/Maurits van Rees/hatchdemo/issues"
+Source = "https://github.com/Maurits van Rees/hatchdemo"
+
+[project.scripts]
+hatchdemo = "hatchdemo:main"
+
+[tool.hatch.version]
+path = "src/hatchdemo/__about__.py"
+
+[tool.hatch.envs.types]
+extra-dependencies = [
+  "mypy>=1.0.0",
+]
+[tool.hatch.envs.types.scripts]
+check = "mypy --install-types --non-interactive {args:src/hatchdemo tests}"
+
+[tool.coverage.run]
+source_pkgs = ["hatchdemo", "tests"]
+branch = true
+parallel = true
+omit = [
+  "src/hatchdemo/__about__.py",
+]
+
+[tool.coverage.paths]
+hatchdemo = ["src/hatchdemo", "*/hatchdemo/src/hatchdemo"]
+tests = ["tests", "*/hatchdemo/tests"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "no cov",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+]

--- a/projects/packages/hatchdemo/src/hatchdemo/__about__.py
+++ b/projects/packages/hatchdemo/src/hatchdemo/__about__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
+#
+# SPDX-License-Identifier: MIT
+__version__ = "0.0.1"

--- a/projects/packages/hatchdemo/src/hatchdemo/__init__.py
+++ b/projects/packages/hatchdemo/src/hatchdemo/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
+#
+# SPDX-License-Identifier: MIT
+
+def main():
+    print("hatchdemo main script")

--- a/projects/packages/hatchdemo/tests/__init__.py
+++ b/projects/packages/hatchdemo/tests/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
-#
-# SPDX-License-Identifier: MIT

--- a/projects/packages/hatchdemo/tests/__init__.py
+++ b/projects/packages/hatchdemo/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
+#
+# SPDX-License-Identifier: MIT

--- a/projects/packages/ns.ancient/LICENSE.txt
+++ b/projects/packages/ns.ancient/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026-present Maurits van Rees <maurits@vanrees.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/projects/packages/ns.ancient/README.md
+++ b/projects/packages/ns.ancient/README.md
@@ -1,0 +1,21 @@
+# ns.ancient
+
+[![PyPI - Version](https://img.shields.io/pypi/v/ns.ancient.svg)](https://pypi.org/project/ns.ancient)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ns.ancient.svg)](https://pypi.org/project/ns.ancient)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install ns.ancient
+```
+
+## License
+
+`ns.ancient` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/projects/packages/ns.ancient/pyproject.toml
+++ b/projects/packages/ns.ancient/pyproject.toml
@@ -1,0 +1,29 @@
+# [build-system]
+# requires = ["setuptools"]
+# build-backend = "setuptools.build_meta"
+
+[project]
+name = "ns.ancient"
+version = "1.0.0"
+description = "Demo package"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["test", "buildout"]
+authors = [
+  { name = "Maurits van Rees", email = "maurits@vanrees.org" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://buildout.org"
+
+[project.scripts]
+ns_ancient = "ns.ancient:main"

--- a/projects/packages/ns.ancient/setup.py
+++ b/projects/packages/ns.ancient/setup.py
@@ -1,0 +1,5 @@
+# This ancient package on purpose still has a setup.py,
+# even though the actual package metadata is in pyproject.toml.
+from setuptools import setup
+
+setup()

--- a/projects/packages/ns.ancient/src/ns/ancient/__init__.py
+++ b/projects/packages/ns.ancient/src/ns/ancient/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
+#
+# SPDX-License-Identifier: MIT
+
+def main():
+    print("ns.ancient main script")

--- a/projects/packages/ns.hat/LICENSE.txt
+++ b/projects/packages/ns.hat/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026-present Maurits van Rees <maurits@vanrees.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/projects/packages/ns.hat/README.md
+++ b/projects/packages/ns.hat/README.md
@@ -1,0 +1,21 @@
+# ns.hat
+
+[![PyPI - Version](https://img.shields.io/pypi/v/ns.hat.svg)](https://pypi.org/project/ns.hat)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ns.hat.svg)](https://pypi.org/project/ns.hat)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install ns.hat
+```
+
+## License
+
+`ns.hat` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/projects/packages/ns.hat/pyproject.toml
+++ b/projects/packages/ns.hat/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ns.hat"
+version = "1.0.0"
+description = "Demo package"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["test", "buildout"]
+authors = [
+  { name = "Maurits van Rees", email = "maurits@vanrees.org" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://buildout.org"
+
+[project.scripts]
+ns_hat = "ns.hat:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ns"]

--- a/projects/packages/ns.hat/src/ns/hat/__init__.py
+++ b/projects/packages/ns.hat/src/ns/hat/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
+#
+# SPDX-License-Identifier: MIT
+
+def main():
+    print("ns.hat main script")

--- a/projects/packages/ns.tools/LICENSE.txt
+++ b/projects/packages/ns.tools/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026-present Maurits van Rees <maurits@vanrees.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/projects/packages/ns.tools/README.md
+++ b/projects/packages/ns.tools/README.md
@@ -1,0 +1,21 @@
+# ns.tools
+
+[![PyPI - Version](https://img.shields.io/pypi/v/ns.tools.svg)](https://pypi.org/project/ns.tools)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/ns.tools.svg)](https://pypi.org/project/ns.tools)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install ns.tools
+```
+
+## License
+
+`ns.tools` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/projects/packages/ns.tools/pyproject.toml
+++ b/projects/packages/ns.tools/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ns.tools"
+version = "1.0.0"
+description = "Demo package"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+keywords = ["test", "buildout"]
+authors = [
+  { name = "Maurits van Rees", email = "maurits@vanrees.org" },
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://buildout.org"
+
+[project.scripts]
+ns_tools = "ns.tools:main"

--- a/projects/packages/ns.tools/src/ns/tools/__init__.py
+++ b/projects/packages/ns.tools/src/ns/tools/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
+#
+# SPDX-License-Identifier: MIT
+
+def main():
+    print("ns.tools main script")

--- a/projects/packages/setuptoolsdemo/LICENSE.txt
+++ b/projects/packages/setuptoolsdemo/LICENSE.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2026-present Maurits van Rees <maurits@vanrees.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/projects/packages/setuptoolsdemo/README.md
+++ b/projects/packages/setuptoolsdemo/README.md
@@ -1,0 +1,21 @@
+# setuptoolsdemo
+
+[![PyPI - Version](https://img.shields.io/pypi/v/setuptoolsdemo.svg)](https://pypi.org/project/setuptoolsdemo)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/setuptoolsdemo.svg)](https://pypi.org/project/setuptoolsdemo)
+
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [License](#license)
+
+## Installation
+
+```console
+pip install setuptoolsdemo
+```
+
+## License
+
+`setuptoolsdemo` is distributed under the terms of the [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/projects/packages/setuptoolsdemo/pyproject.toml
+++ b/projects/packages/setuptoolsdemo/pyproject.toml
@@ -1,9 +1,9 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
-name = "hatchdemo"
+name = "setuptoolsdemo"
 version = "1.0.0"
 description = "Demo package"
 readme = "README.md"
@@ -26,4 +26,4 @@ dependencies = []
 Documentation = "https://buildout.org"
 
 [project.scripts]
-hatchdemo = "hatchdemo:main"
+setuptoolsdemo = "setuptoolsdemo:main"

--- a/projects/packages/setuptoolsdemo/src/setuptoolsdemo/__init__.py
+++ b/projects/packages/setuptoolsdemo/src/setuptoolsdemo/__init__.py
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2026-present Maurits van Rees <maurits@vanrees.org>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1"
+
+def main():
+    print("setuptoolsdemo main script")

--- a/projects/requirements/final.txt
+++ b/projects/requirements/final.txt
@@ -1,4 +1,5 @@
 packages/hatchdemo
 packages/setuptoolsdemo
+packages/ns.ancient
 packages/ns.hat
 packages/ns.tools

--- a/projects/requirements/final.txt
+++ b/projects/requirements/final.txt
@@ -1,0 +1,4 @@
+packages/hatchdemo
+packages/setuptoolsdemo
+packages/ns.hat
+packages/ns.tools

--- a/projects/requirements/mixed.txt
+++ b/projects/requirements/mixed.txt
@@ -1,3 +1,3 @@
 -e packages/ns.ancient
 -e packages/ns.hat
--e packages/ns.tools
+packages/ns.tools

--- a/projects/requirements/namespaces.txt
+++ b/projects/requirements/namespaces.txt
@@ -1,0 +1,2 @@
+-e packages/ns.hat
+-e packages/ns.tools

--- a/projects/requirements/simple.txt
+++ b/projects/requirements/simple.txt
@@ -1,0 +1,1 @@
+-e packages/hatchdemo

--- a/projects/requirements/simple.txt
+++ b/projects/requirements/simple.txt
@@ -1,1 +1,2 @@
 -e packages/hatchdemo
+-e packages/setuptoolsdemo


### PR DESCRIPTION
Run `make test-projects` to use the generated `bin/buildout` to run various small buildouts with test packages.  The source code for the test packages, and the buildout configs, are in the new `projects` directory`.

I have updated the main GHA file to first run `make test-projects`, and then run the other tests.  This will make it fail much sooner in case of problems.  And they will be *real* problems instead of just some unimportant difference in doctest output.

I actually started this to have a small, reproducible buildout that would show a problem in an environment with some non-working mix of setuptools/hatchling/namespaces packages.  But everything works!

Let me close with a paste of the new `projects/README-projects.md` file, which explains everything, and should be nicely readable here:

# Test projects

## Introduction

Within this `projects` directory are three directories: `packages`, `buildouts`, and `requirements`.
I want to use this to really test some common scenarios in a debuggable way.
Meaning: no doctests, simply run `bin/buildout` with a config, so you can add a breakpoint.


## Usage:

Within the main directory, so one level up, you can run:

```
make test-projects
```

This runs `make` within the `projects` directory, so you can also go to the `projects` directory yourself and run make:

```
make
```

Or run a single one:

```
make simple
```

In most of the `Makefile` targets we go to one of the buildout directories.
There we run `bin/buildout` from the top-level directory.


## Buildouts

Each sub directory has a `buildout.cfg` that does the following:

* `develop` zero, one, or more of our packages.
* Create a `bin/testscript` that has all those packages.
  With this you can check if you can import them.
* Automatically create the console scripts that each package defines.
  With this you can check that entry points are found correctly and the script works.

### Shared config

The buildouts extend `projects/buildout/shared.cfg` which has the common config.
Among others, it defines a download cache in `projects/downloads/dist`, and an eggs cache in `projects/eggs`.

### Downloads

The `make downloads` target creates final wheels of all our packages, and puts them in `projects/downloads/dist`, so buildouts can find them.

### Current buildouts

* `simple`: `hatchdemo` and `setuptoolsdemo` packages
* `namespaces`: `ns.ancient`, `ns.hat` and `ns.tools` packages
* `final`: all packages in final form, installed from a wheel in the downloads cache
* `mixed`: all namespace packages, some in development, some final

The buildout that I most expect to fail, is the mixed one.
But so far it works.


## Packages

Each package registers a console script so you can check that the package can find itself.
I want to focus on modern packaging methods:

* No `setup.py`, just `pyproject.toml`.
* Everything in a `src` directory.
* Not just `setuptools`, also `hatchling` or other projects.
* Only native namespaces, when used.


### Current packages:

* `hatchdemo`: basic package using `hatchling`
* `setuptoolsdemo`: basic package using `setuptools`
* `ns.hat`: namespace package using `hatchling`
* `ns.tools`: namespace package using `setuptools`
* `ns.ancient`: namespace package using `setuptools`, and still a `setup.py`


### New package

I created the basis of the `hatchdemo` package with this command:

```
uvx hatch new hatchdemo
```

So if you want to create a new package, you can use the same command.
But copying and editing is likely easier.
That is what I did for the other projects.
I removed lots of metadata though, which we did not need.

If you create your own package by hand, make sure to register a console script in `pyroject.toml`:

```
[project.scripts]
<script name> = "<package name>:main"
```

And add a function in the `__init__.py` of the package, printing the name of the package:

```
def main():
    print("<package name> main script")
```

Or you copy an existing demo package and go from there.


## Compare with pip/uv

Each buildout config should have a mirror in a requirements file in the `requirements` directory.
If any scripts don't work there, there is not much point in trying to get this to work in Buildout.

```
make pips
```

Note: when you run `make` or `make all`, the `pips` target is not run, as we only want to know if our buildouts work.
